### PR TITLE
Update cobblerclient to 0.5.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@
 #
 # You will need to pass the `--batch` flag to `gpg` in your signing step
 # in `goreleaser` to indicate this is being used in a non-interactive mode.
+name: Release
 
 on:
   pull_request:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -38,14 +38,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
       - run: go test -v -cover ./...
   test:
-    name: Integration Tests
+    name: Integration Tests (Cobbler ${{ matrix.cobbler_version }})
     needs: build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cobbler_version:
+          # - d8f60bbf14a838c8c8a1dba98086b223e35fe70a # 3.3.0 - TypeError during import
+          - f5b0599acce32de4288c76e4f601aece0c664fed # 3.3.1
+          # - 9044aa990a94752fa5bd5a24051adde099280bfa # 3.3.2 - Testing Docker Image broken
+          # - 5c498dbf2af6e3782b37605a477759e1aacc16b2 # 3.3.3 - Testing Docker Image broken
+          - 3ed865b79ce69fca7464e0957f4bcadcc9917a9d # 3.3.4
+          - 718e3256a5989941e8a678404fdea07364255637 # 3.3.5
+          - df356046f3cf27be62a61001b982d5983800cfd9 # 3.3.6
+      fail-fast: false
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
@@ -54,12 +65,32 @@ jobs:
         with:
           go-version-file: 'go.mod'
         id: go
+      - name: Set up Terraform
+        # https://github.com/hashicorp/setup-terraform
+        uses: hashicorp/setup-terraform@v3
+      - name: Install system dependencies
+        run: |
+          sudo apt-get install -y xorriso
       - name: Get dependencies
         run: |
           go mod download
+      - name: Replace git version hash
+        run: |
+          sed -i "s/cobbler_commit=.*/cobbler_commit=${{ matrix.cobbler_version }}/" docker/start.sh
+      - name: Restore OS ISO
+        id: cache-iso-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            *.iso
+          key: ${{ runner.os }}-${{ matrix.cobbler_version }}-iso
       - name: Make Test
         run: |
           make testacc
-      - name: Make Vet
-        run: |
-          make vet
+      - name: Save OS ISO
+        id: cache-iso-save
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            *.iso
+          key: ${{ steps.cache-iso-restore.outputs.cache-primary-key }}

--- a/cobbler/resource_cobbler_distro.go
+++ b/cobbler/resource_cobbler_distro.go
@@ -32,12 +32,20 @@ func resourceDistro() *schema.Resource {
 				ForceNew:    true,
 			},
 			"boot_files": {
-				Description: "Files copied into tftpboot beyond the kernel/initrd.",
-				Type:        schema.TypeMap,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Optional:    true,
-				ForceNew:    true,
-				Computed:    true,
+				Description:   "Files copied into tftpboot beyond the kernel/initrd.",
+				Type:          schema.TypeMap,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Optional:      true,
+				ForceNew:      true,
+				Computed:      true,
+				ConflictsWith: []string{"boot_files_inherit"},
+			},
+			"boot_files_inherit": {
+				Description:   "Signal that boot_files should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"boot_files"},
 			},
 			"boot_loaders": {
 				Description: "Must be either 'grub', 'pxe', or 'ipxe'.",
@@ -46,6 +54,13 @@ func resourceDistro() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 				Computed:    true,
+			},
+			"boot_loaders_inherit": {
+				Description:   "Signal that boot_loaders should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"boot_loaders"},
 			},
 			"comment": {
 				Description: "Free form text description.",
@@ -59,6 +74,13 @@ func resourceDistro() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,
 				Computed:    true,
+			},
+			"fetchable_files_inherit": {
+				Description:   "Signal that fetchable_files should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"fetchable_files"},
 			},
 			"initrd": {
 				Description: "Absolute path to initrd on filesystem. This must already exist prior to creating the distro.",
@@ -77,11 +99,25 @@ func resourceDistro() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"kernel_options_inherit": {
+				Description:   "Signal that kernel_options should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"kernel_options"},
+			},
 			"kernel_options_post": {
 				Description: "Post install Kernel options to use with the kernel after installation.",
 				Type:        schema.TypeMap,
 				Optional:    true,
 				Computed:    true,
+			},
+			"kernel_options_post_inherit": {
+				Description:   "Signal that kernel_options_post should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"kernel_options_post"},
 			},
 			"mgmt_classes": {
 				Description: "Management classes for external config management.",
@@ -89,6 +125,13 @@ func resourceDistro() *schema.Resource {
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Computed:    true,
+			},
+			"mgmt_classes_inherit": {
+				Description:   "Signal that mgmt_classes should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"mgmt_classes"},
 			},
 			"name": {
 				Description: "A name for the distro.",
@@ -107,12 +150,26 @@ func resourceDistro() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Computed:    true,
 			},
+			"owners_inherit": {
+				Description:   "Signal that owners should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"owners"},
+			},
 			"template_files": {
 				Description: "File mappings for built-in config management.",
 				Type:        schema.TypeMap,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,
 				Computed:    true,
+			},
+			"template_files_inherit": {
+				Description:   "Signal that template_files should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"template_files"},
 			},
 		},
 	}
@@ -159,11 +216,11 @@ func resourceDistroRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("boot_files", distro.BootFiles.Data)
+	err = SetInherit(d, "boot_files", distro.BootFiles, make(map[string]interface{}))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("boot_loaders", distro.BootLoaders.Data)
+	err = SetInherit(d, "boot_loaders", distro.BootLoaders, make([]string, 0))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -171,7 +228,7 @@ func resourceDistroRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("fetchable_files", distro.FetchableFiles.Data)
+	err = SetInherit(d, "fetchable_files", distro.FetchableFiles, make(map[string]interface{}))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -183,11 +240,11 @@ func resourceDistroRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("kernel_options", distro.KernelOptions.Data)
+	err = SetInherit(d, "kernel_options", distro.KernelOptions, make(map[string]interface{}))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("kernel_options_post", distro.KernelOptionsPost.Data)
+	err = SetInherit(d, "kernel_options_post", distro.KernelOptionsPost, make(map[string]interface{}))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -195,7 +252,7 @@ func resourceDistroRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("mgmt_classes", distro.MgmtClasses.Data)
+	err = SetInherit(d, "mgmt_classes", distro.MgmtClasses, make([]string, 0))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -203,11 +260,11 @@ func resourceDistroRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("owners", distro.Owners.Data)
+	err = SetInherit(d, "owners", distro.Owners, make([]string, 0))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("template_files", distro.TemplateFiles.Data)
+	err = SetInherit(d, "template_files", distro.TemplateFiles, make(map[string]interface{}))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -288,40 +345,40 @@ func buildDistro(d *schema.ResourceData, meta interface{}) (cobbler.Distro, erro
 	distro.Breed = d.Get("breed").(string)
 	distro.BootFiles = cobbler.Value[map[string]interface{}]{
 		Data:        bootFiles,
-		IsInherited: false,
+		IsInherited: d.Get("boot_files_inherit").(bool),
 	}
 	distro.BootLoaders = cobbler.Value[[]string]{
 		Data:        bootLoaders,
-		IsInherited: false,
+		IsInherited: d.Get("boot_loaders_inherit").(bool),
 	}
 	distro.Comment = d.Get("comment").(string)
 	distro.FetchableFiles = cobbler.Value[map[string]interface{}]{
 		Data:        fetchableFiles,
-		IsInherited: false,
+		IsInherited: d.Get("fetchable_files_inherit").(bool),
 	}
 	distro.Kernel = d.Get("kernel").(string)
 	distro.KernelOptions = cobbler.Value[map[string]interface{}]{
 		Data:        kernelOptions,
-		IsInherited: false,
+		IsInherited: d.Get("kernel_options_inherit").(bool),
 	}
 	distro.KernelOptionsPost = cobbler.Value[map[string]interface{}]{
 		Data:        kernelOptionsPost,
-		IsInherited: false,
+		IsInherited: d.Get("kernel_options_post_inherit").(bool),
 	}
 	distro.Initrd = d.Get("initrd").(string)
 	distro.MgmtClasses = cobbler.Value[[]string]{
 		Data:        mgmtClasses,
-		IsInherited: false,
+		IsInherited: d.Get("mgmt_classes_inherit").(bool),
 	}
 	distro.Name = d.Get("name").(string)
 	distro.OSVersion = d.Get("os_version").(string)
 	distro.Owners = cobbler.Value[[]string]{
 		Data:        owners,
-		IsInherited: false,
+		IsInherited: d.Get("owners_inherit").(bool),
 	}
 	distro.TemplateFiles = cobbler.Value[map[string]interface{}]{
 		Data:        templateFiles,
-		IsInherited: false,
+		IsInherited: d.Get("template_files_inherit").(bool),
 	}
 
 	return distro, nil

--- a/cobbler/resource_cobbler_distro_test.go
+++ b/cobbler/resource_cobbler_distro_test.go
@@ -26,6 +26,24 @@ func TestAccCobblerDistro_basic(t *testing.T) {
 	})
 }
 
+func TestAccCobblerDistro_basic_inherit(t *testing.T) {
+	var distro cobbler.Distro
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccCobblerPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCobblerCheckDistroDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCobblerDistroBasicInherit,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCobblerCheckDistroExists("cobbler_distro.foo", &distro),
+				),
+			},
+		},
+	})
+}
+
 func TestAccCobblerDistro_change(t *testing.T) {
 	var distro cobbler.Distro
 
@@ -94,6 +112,17 @@ var testAccCobblerDistroBasic = `
 		kernel = "/srv/www/cobbler/distro_mirror/Ubuntu-20.04/install/vmlinuz"
 		initrd = "/srv/www/cobbler/distro_mirror/Ubuntu-20.04/install/initrd.gz"
 		boot_loaders = ["ipxe"]
+	}`
+
+var testAccCobblerDistroBasicInherit = `
+	resource "cobbler_distro" "foo" {
+		name = "foo"
+		breed = "ubuntu"
+		os_version = "focal"
+		arch = "x86_64"
+		kernel = "/srv/www/cobbler/distro_mirror/Ubuntu-20.04/install/vmlinuz"
+		initrd = "/srv/www/cobbler/distro_mirror/Ubuntu-20.04/install/initrd.gz"
+		boot_loaders_inherit = true
 	}`
 
 var testAccCobblerDistroChange1 = `

--- a/cobbler/resource_cobbler_distro_test.go
+++ b/cobbler/resource_cobbler_distro_test.go
@@ -55,7 +55,7 @@ func testAccCobblerCheckDistroDestroy(s *terraform.State) error {
 		if rs.Type != "cobbler_distro" {
 			continue
 		}
-		if _, err := cobblerApiClient.GetDistro(rs.Primary.ID); err == nil {
+		if _, err := cobblerApiClient.GetDistro(rs.Primary.ID, false, false); err == nil {
 			//goland:noinspection GoErrorStringFormat
 			return fmt.Errorf("Distro still exists")
 		}
@@ -72,7 +72,7 @@ func testAccCobblerCheckDistroExists(n string, distro *cobbler.Distro) resource.
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("no ID is set")
 		}
-		found, err := cobblerApiClient.GetDistro(rs.Primary.ID)
+		found, err := cobblerApiClient.GetDistro(rs.Primary.ID, false, false)
 		if err != nil {
 			return err
 		}

--- a/cobbler/resource_cobbler_profile.go
+++ b/cobbler/resource_cobbler_profile.go
@@ -31,12 +31,26 @@ func resourceProfile() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"autoinstall_meta_inherit": {
+				Description:   "Signal that autoinstall_meta should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"autoinstall_meta"},
+			},
 			"boot_files": {
 				Description: "Files copied into tftpboot beyond the kernel/initrd.",
 				Type:        schema.TypeMap,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,
 				Computed:    true,
+			},
+			"boot_files_inherit": {
+				Description:   "Signal that boot_files should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"boot_files"},
 			},
 			"comment": {
 				Description: "Free form text description.",
@@ -60,11 +74,25 @@ func resourceProfile() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"enable_gpxe_inherit": {
+				Description:   "Signal that enable_gpxe should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"enable_gpxe"},
+			},
 			"enable_menu": {
 				Description: "Enable a boot menu.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
+			},
+			"enable_menu_inherit": {
+				Description:   "Signal that enable_menu should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"enable_menu"},
 			},
 			"fetchable_files": {
 				Description: "Templates for tftp or wget.",
@@ -73,6 +101,13 @@ func resourceProfile() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"fetchable_files_inherit": {
+				Description:   "Signal that fetchable_files should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"fetchable_files"},
+			},
 			"kernel_options": {
 				Description: "Kernel options for the profile.",
 				Type:        schema.TypeMap,
@@ -80,11 +115,25 @@ func resourceProfile() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"kernel_options_inherit": {
+				Description:   "Signal that kernel_options should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"kernel_options"},
+			},
 			"kernel_options_post": {
 				Description: "Post install kernel options.",
 				Type:        schema.TypeMap,
 				Optional:    true,
 				Computed:    true,
+			},
+			"kernel_options_post_inherit": {
+				Description:   "Signal that kernel_options_post should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"kernel_options_post"},
 			},
 			"mgmt_classes": {
 				Description: "For external configuration management.",
@@ -93,11 +142,25 @@ func resourceProfile() *schema.Resource {
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"mgmt_classes_inherit": {
+				Description:   "Signal that mgmt_classes should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"mgmt_classes"},
+			},
 			"mgmt_parameters": {
 				Description: "Parameters which will be handed to your management application (Must be a valid YAML dictionary).",
 				Type:        schema.TypeMap,
 				Optional:    true,
 				Computed:    true,
+			},
+			"mgmt_parameters_inherit": {
+				Description:   "Signal that mgmt_parameters should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"mgmt_parameters"},
 			},
 			"name": {
 				Description: "The name of the profile.",
@@ -112,12 +175,26 @@ func resourceProfile() *schema.Resource {
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"name_servers_search_inherit": {
+				Description:   "Signal that name_servers_search should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"name_servers_search"},
+			},
 			"name_servers": {
 				Description: "Name servers.",
 				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"name_servers_inherit": {
+				Description:   "Signal that name_servers should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"name_servers"},
 			},
 			"next_server_v4": {
 				Description: "The next_server_v4 option is used for DHCP/PXE as the IP of the TFTP server from which network boot files are downloaded. Usually, this will be the same IP as the server setting.",
@@ -137,6 +214,13 @@ func resourceProfile() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"owners_inherit": {
+				Description:   "Signal that owners should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"owners"},
 			},
 			"parent": {
 				Description: "The parent this profile inherits settings from.",
@@ -170,11 +254,25 @@ func resourceProfile() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"template_files_inherit": {
+				Description:   "Signal that template_files should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"template_files"},
+			},
 			"virt_auto_boot": {
 				Description: "Auto boot virtual machines.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
+			},
+			"virt_auto_boot_inherit": {
+				Description:   "Signal that virt_auto_boot should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"virt_auto_boot"},
 			},
 			"virt_bridge": {
 				Description: "The bridge for virtual machines.",
@@ -200,6 +298,13 @@ func resourceProfile() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"virt_file_size_inherit": {
+				Description:   "Signal that virt_file_size should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"virt_file_size"},
+			},
 			"virt_path": {
 				Description: "The virtual machine path.",
 				Type:        schema.TypeString,
@@ -211,6 +316,13 @@ func resourceProfile() *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Computed:    true,
+			},
+			"virt_ram_inherit": {
+				Description:   "Signal that virt_ram should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"virt_ram"},
 			},
 			"virt_type": {
 				Description: "The type of virtual machine. Valid options are: xenpv, xenfv, qemu, kvm, vmware, openvz.",
@@ -259,11 +371,11 @@ func resourceProfileRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("autoinstall_meta", profile.AutoinstallMeta.Data)
+	err = SetInherit(d, "autoinstall_meta", profile.AutoinstallMeta, make(map[string]interface{}))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("boot_files", profile.BootFiles.Data)
+	err = SetInherit(d, "boot_files", profile.BootFiles, make(map[string]interface{}))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -280,50 +392,43 @@ func resourceProfileRead(ctx context.Context, d *schema.ResourceData, meta inter
 		return diag.FromErr(err)
 	}
 	// TODO: enable_ipxe
-	err = d.Set("enable_gpxe", profile.EnableIPXE.Data)
+	err = SetInherit(d, "enable_gpxe", profile.EnableIPXE, false)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("enable_menu", profile.EnableMenu.Data)
+	err = SetInherit(d, "enable_menu", profile.EnableMenu, false)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("fetchable_files", profile.FetchableFiles.Data)
+	err = SetInherit(d, "fetchable_files", profile.FetchableFiles, make(map[string]interface{}))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("kernel_options", profile.KernelOptions.Data)
+	err = SetInherit(d, "kernel_options", profile.KernelOptions, make(map[string]interface{}))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("kernel_options_post", profile.KernelOptionsPost.Data)
+	err = SetInherit(d, "kernel_options_post", profile.KernelOptionsPost, make(map[string]interface{}))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("mgmt_classes", profile.MgmtClasses.Data)
+	err = SetInherit(d, "mgmt_classes", profile.MgmtClasses, make([]string, 0))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	if profile.MgmtParameters.IsInherited {
-		err = d.Set("mgmt_parameters", make(map[string]interface{}))
-		if err != nil {
-			return diag.FromErr(err)
-		}
-	} else {
-		err = d.Set("mgmt_parameters", profile.MgmtParameters.Data)
-		if err != nil {
-			return diag.FromErr(err)
-		}
+	err = SetInherit(d, "mgmt_parameters", profile.MgmtParameters, make(map[string]interface{}))
+	if err != nil {
+		return diag.FromErr(err)
 	}
 	err = d.Set("name", profile.Name)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("name_servers_search", profile.NameServersSearch.Data)
+	err = SetInherit(d, "name_servers_search", profile.NameServersSearch, make([]string, 0))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("name_servers", profile.NameServers.Data)
+	err = SetInherit(d, "name_servers", profile.NameServers, make([]string, 0))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -335,7 +440,7 @@ func resourceProfileRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("owners", profile.Owners.Data)
+	err = SetInherit(d, "owners", profile.Owners, make([]string, 0))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -347,11 +452,11 @@ func resourceProfileRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("template_files", profile.TemplateFiles.Data)
+	err = SetInherit(d, "template_files", profile.TemplateFiles, make(map[string]interface{}))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("virt_auto_boot", profile.VirtAutoBoot.Data)
+	err = SetInherit(d, "virt_auto_boot", profile.VirtAutoBoot, false)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -367,17 +472,15 @@ func resourceProfileRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	if !profile.VirtFileSize.IsInherited {
-		err = d.Set("virt_file_size", profile.VirtFileSize.Data)
-		if err != nil {
-			return diag.FromErr(err)
-		}
+	err = SetInherit(d, "virt_file_size", profile.VirtFileSize, 0)
+	if err != nil {
+		return diag.FromErr(err)
 	}
 	err = d.Set("virt_path", profile.VirtPath)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("virt_ram", profile.VirtRAM.Data)
+	err = SetInherit(d, "virt_ram", profile.VirtRAM, 0)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -481,7 +584,7 @@ func buildProfile(d *schema.ResourceData, meta interface{}) (cobbler.Profile, er
 	}
 	profile.BootFiles = cobbler.Value[map[string]interface{}]{
 		Data:        bootFiles,
-		IsInherited: false,
+		IsInherited: d.Get("boot_files_inherit").(bool),
 	}
 	profile.Comment = d.Get("comment").(string)
 	profile.DHCPTag = d.Get("dhcp_tag").(string)
@@ -489,69 +592,69 @@ func buildProfile(d *schema.ResourceData, meta interface{}) (cobbler.Profile, er
 	// TODO: enable_ipxe
 	profile.EnableIPXE = cobbler.Value[bool]{
 		Data:        d.Get("enable_gpxe").(bool),
-		IsInherited: false,
+		IsInherited: d.Get("enable_gpxe_inherit").(bool),
 	}
 	profile.EnableMenu = cobbler.Value[bool]{
 		Data:        d.Get("enable_menu").(bool),
-		IsInherited: false,
+		IsInherited: d.Get("enable_menu_inherit").(bool),
 	}
 	profile.FetchableFiles = cobbler.Value[map[string]interface{}]{
 		Data:        fetchableFiles,
-		IsInherited: false,
+		IsInherited: d.Get("fetchable_files_inherit").(bool),
 	}
 	profile.KernelOptions = cobbler.Value[map[string]interface{}]{
 		Data:        kernelOptions,
-		IsInherited: false,
+		IsInherited: d.Get("kernel_options_inherit").(bool),
 	}
 	profile.KernelOptionsPost = cobbler.Value[map[string]interface{}]{
 		Data:        kernelOptionsPost,
-		IsInherited: false,
+		IsInherited: d.Get("kernel_options_post_inherit").(bool),
 	}
 	profile.MgmtClasses = cobbler.Value[[]string]{
 		Data:        mgmtClasses,
-		IsInherited: false,
+		IsInherited: d.Get("mgmt_classes_inherit").(bool),
 	}
 	profile.MgmtParameters = cobbler.Value[map[string]interface{}]{
 		Data:        mgmtParameters,
-		IsInherited: false,
+		IsInherited: d.Get("mgmt_parameters_inherit").(bool),
 	}
 	profile.Name = d.Get("name").(string)
 	profile.NameServersSearch = cobbler.Value[[]string]{
 		Data:        nameServersSearch,
-		IsInherited: false,
+		IsInherited: d.Get("name_servers_search_inherit").(bool),
 	}
 	profile.NameServers = cobbler.Value[[]string]{
 		Data:        nameServers,
-		IsInherited: false,
+		IsInherited: d.Get("name_servers_inherit").(bool),
 	}
 	profile.NextServerv4 = d.Get("next_server_v4").(string)
 	profile.NextServerv6 = d.Get("next_server_v6").(string)
 	profile.Owners = cobbler.Value[[]string]{
 		Data:        owners,
-		IsInherited: false,
+		IsInherited: d.Get("owners_inherit").(bool),
 	}
 	profile.Proxy = d.Get("proxy").(string)
 	profile.Repos = repos
 	profile.Server = d.Get("server").(string)
 	profile.TemplateFiles = cobbler.Value[map[string]interface{}]{
 		Data:        templateFiles,
-		IsInherited: false,
+		IsInherited: d.Get("template_files_inherit").(bool),
 	}
 	profile.VirtAutoBoot = cobbler.Value[bool]{
 		Data:        d.Get("virt_auto_boot").(bool),
-		IsInherited: false,
+		IsInherited: d.Get("virt_auto_boot_inherit").(bool),
 	}
 	profile.VirtBridge = d.Get("virt_bridge").(string)
 	profile.VirtCPUs = d.Get("virt_cpus").(int)
 	profile.VirtDiskDriver = d.Get("virt_disk_driver").(string)
 	profile.VirtFileSize = cobbler.Value[float64]{
 		Data:        d.Get("virt_file_size").(float64),
-		IsInherited: false,
+		IsInherited: d.Get("virt_file_size_inherit").(bool),
 	}
 	profile.VirtPath = d.Get("virt_path").(string)
 	profile.VirtRAM = cobbler.Value[int]{
 		Data:        d.Get("virt_ram").(int),
-		IsInherited: false,
+		IsInherited: d.Get("virt_ram_inherit").(bool),
 	}
 	profile.VirtType = d.Get("virt_type").(string)
 

--- a/cobbler/resource_cobbler_profile.go
+++ b/cobbler/resource_cobbler_profile.go
@@ -68,18 +68,18 @@ func resourceProfile() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
-			"enable_gpxe": {
-				Description: "Use gPXE instead of PXELINUX for advanced booting options.",
+			"enable_ipxe": {
+				Description: "Use iPXE instead of PXELINUX for advanced booting options.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
 			},
-			"enable_gpxe_inherit": {
-				Description:   "Signal that enable_gpxe should be set to inherit from its parent",
+			"enable_ipxe_inherit": {
+				Description:   "Signal that enable_ipxe should be set to inherit from its parent",
 				Type:          schema.TypeBool,
 				Optional:      true,
 				Computed:      true,
-				ConflictsWith: []string{"enable_gpxe"},
+				ConflictsWith: []string{"enable_ipxe"},
 			},
 			"enable_menu": {
 				Description: "Enable a boot menu.",
@@ -391,8 +391,7 @@ func resourceProfileRead(ctx context.Context, d *schema.ResourceData, meta inter
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	// TODO: enable_ipxe
-	err = SetInherit(d, "enable_gpxe", profile.EnableIPXE, false)
+	err = SetInherit(d, "enable_ipxe", profile.EnableIPXE, false)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -589,10 +588,9 @@ func buildProfile(d *schema.ResourceData, meta interface{}) (cobbler.Profile, er
 	profile.Comment = d.Get("comment").(string)
 	profile.DHCPTag = d.Get("dhcp_tag").(string)
 	profile.Distro = d.Get("distro").(string)
-	// TODO: enable_ipxe
 	profile.EnableIPXE = cobbler.Value[bool]{
-		Data:        d.Get("enable_gpxe").(bool),
-		IsInherited: d.Get("enable_gpxe_inherit").(bool),
+		Data:        d.Get("enable_ipxe").(bool),
+		IsInherited: d.Get("enable_ipxe_inherit").(bool),
 	}
 	profile.EnableMenu = cobbler.Value[bool]{
 		Data:        d.Get("enable_menu").(bool),

--- a/cobbler/resource_cobbler_profile_test.go
+++ b/cobbler/resource_cobbler_profile_test.go
@@ -81,7 +81,7 @@ func testAccCobblerCheckProfileDestroy(s *terraform.State) error {
 			continue
 		}
 
-		if _, err := cobblerApiClient.GetProfile(rs.Primary.ID); err == nil {
+		if _, err := cobblerApiClient.GetProfile(rs.Primary.ID, false, false); err == nil {
 			//goland:noinspection GoErrorStringFormat
 			return fmt.Errorf("Profile still exists")
 		}
@@ -101,7 +101,7 @@ func testAccCobblerCheckProfileExists(n string, profile *cobbler.Profile) resour
 			return fmt.Errorf("no ID is set")
 		}
 
-		found, err := cobblerApiClient.GetProfile(rs.Primary.ID)
+		found, err := cobblerApiClient.GetProfile(rs.Primary.ID, false, false)
 		if err != nil {
 			return err
 		}

--- a/cobbler/resource_cobbler_repo_test.go
+++ b/cobbler/resource_cobbler_repo_test.go
@@ -58,7 +58,7 @@ func testAccCobblerCheckRepoDestroy(s *terraform.State) error {
 			continue
 		}
 
-		if _, err := cobblerApiClient.GetRepo(rs.Primary.ID); err == nil {
+		if _, err := cobblerApiClient.GetRepo(rs.Primary.ID, false, false); err == nil {
 			//goland:noinspection GoErrorStringFormat
 			return fmt.Errorf("Repo still exists")
 		}
@@ -78,7 +78,7 @@ func testAccCobblerCheckRepoExists(n string, repo *cobbler.Repo) resource.TestCh
 			return fmt.Errorf("no ID is set")
 		}
 
-		found, err := cobblerApiClient.GetRepo(rs.Primary.ID)
+		found, err := cobblerApiClient.GetRepo(rs.Primary.ID, false, false)
 		if err != nil {
 			return err
 		}

--- a/cobbler/resource_cobbler_system.go
+++ b/cobbler/resource_cobbler_system.go
@@ -80,18 +80,18 @@ func resourceSystem() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
-			"enable_gpxe": {
-				Description: "Use gPXE instead of PXELINUX for advanced booting options.",
+			"enable_ipxe": {
+				Description: "Use iPXE instead of PXELINUX for advanced booting options.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
 			},
-			"enable_gpxe_inherit": {
-				Description:   "Signal that enable_gpxe should be set to inherit from its parent",
+			"enable_ipxe_inherit": {
+				Description:   "Signal that enable_ipxe should be set to inherit from its parent",
 				Type:          schema.TypeBool,
 				Optional:      true,
 				Computed:      true,
-				ConflictsWith: []string{"enable_gpxe"},
+				ConflictsWith: []string{"enable_ipxe"},
 			},
 			"fetchable_files": {
 				Description: "Templates for tftp or wget.",
@@ -601,8 +601,7 @@ func resourceSystemRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	// TODO: enable_ipxe
-	err = SetInherit(d, "enable_gpxe", system.EnableIPXE, false)
+	err = SetInherit(d, "enable_ipxe", system.EnableIPXE, false)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -951,10 +950,9 @@ func buildSystem(d *schema.ResourceData) (cobbler.System, error) {
 		IsInherited: d.Get("boot_loaders_inherit").(bool),
 	}
 	system.Comment = d.Get("comment").(string)
-	// TODO: enable_ipxe
 	system.EnableIPXE = cobbler.Value[bool]{
-		Data:        d.Get("enable_gpxe").(bool),
-		IsInherited: d.Get("enable_gpxe_inherit").(bool),
+		Data:        d.Get("enable_ipxe").(bool),
+		IsInherited: d.Get("enable_ipxe_inherit").(bool),
 	}
 	system.FetchableFiles = cobbler.Value[map[string]interface{}]{
 		Data:        fetchableFiles,

--- a/cobbler/resource_cobbler_system.go
+++ b/cobbler/resource_cobbler_system.go
@@ -40,11 +40,25 @@ func resourceSystem() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"autoinstall_meta_inherit": {
+				Description:   "Signal that autoinstall_meta should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"autoinstall_meta"},
+			},
 			"boot_files": {
 				Description: "Files copied into tftpboot beyond the kernel/initrd.",
 				Type:        schema.TypeMap,
 				Optional:    true,
 				Computed:    true,
+			},
+			"boot_files_inherit": {
+				Description:   "Signal that boot_files should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"boot_files"},
 			},
 			"boot_loaders": {
 				Description: "Must be either `grub`, `pxe`, or `ipxe`.",
@@ -53,21 +67,32 @@ func resourceSystem() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
-
+			"boot_loaders_inherit": {
+				Description:   "Signal that boot_loaders should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"boot_loaders"},
+			},
 			"comment": {
 				Description: "Free form text description.",
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
 			},
-
 			"enable_gpxe": {
 				Description: "Use gPXE instead of PXELINUX for advanced booting options.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
 			},
-
+			"enable_gpxe_inherit": {
+				Description:   "Signal that enable_gpxe should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"enable_gpxe"},
+			},
 			"fetchable_files": {
 				Description: "Templates for tftp or wget.",
 				Type:        schema.TypeMap,
@@ -75,28 +100,31 @@ func resourceSystem() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
-
+			"fetchable_files_inherit": {
+				Description:   "Signal that fetchable_files should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"fetchable_files"},
+			},
 			"gateway": {
 				Description: "Network gateway.",
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
 			},
-
 			"hostname": {
 				Description: "Hostname of the system.",
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
 			},
-
 			"image": {
 				Description: "Parent image (if no profile is used).",
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
 			},
-
 			"interface": {
 				Description: "The `interface` Block Set.",
 				Type:        schema.TypeSet,
@@ -252,11 +280,25 @@ func resourceSystem() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"kernel_options_inherit": {
+				Description:   "Signal that kernel_options should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"kernel_options"},
+			},
 			"kernel_options_post": {
 				Description: "Kernel options (post install).",
 				Type:        schema.TypeMap,
 				Optional:    true,
 				Computed:    true,
+			},
+			"kernel_options_post_inherit": {
+				Description:   "Signal that kernel_options_post should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"kernel_options_post"},
 			},
 			"mgmt_classes": {
 				Description: "For external configuration management.",
@@ -265,11 +307,25 @@ func resourceSystem() *schema.Resource {
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"mgmt_classes_inherit": {
+				Description:   "Signal that mgmt_classes should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"mgmt_classes"},
+			},
 			"mgmt_parameters": {
 				Description: "Parameters which will be handed to your management application (Must be a valid YAML dictionary).",
 				Type:        schema.TypeMap,
 				Optional:    true,
 				Computed:    true,
+			},
+			"mgmt_parameters_inherit": {
+				Description:   "Signal that mgmt_parameters should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"mgmt_parameters"},
 			},
 			"name": {
 				Description: "The name of the system.",
@@ -315,6 +371,13 @@ func resourceSystem() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"owners_inherit": {
+				Description:   "Signal that owners should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"owners"},
 			},
 			"power_address": {
 				Description: "Power management address.",
@@ -370,11 +433,25 @@ func resourceSystem() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"template_files_inherit": {
+				Description:   "Signal that template_files should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"template_files"},
+			},
 			"virt_auto_boot": {
 				Description: "Auto boot virtual machines.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
+			},
+			"virt_auto_boot_inherit": {
+				Description:   "Signal that virt_auto_boot should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"virt_auto_boot"},
 			},
 			"virt_file_size": {
 				Description: "The virtual machine file size.",
@@ -382,11 +459,25 @@ func resourceSystem() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"virt_file_size_inherit": {
+				Description:   "Signal that virt_file_size should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"virt_file_size"},
+			},
 			"virt_cpus": {
 				Description: "The number of virtual CPUs",
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Computed:    true,
+			},
+			"virt_cpus_inherit": {
+				Description:   "Signal that virt_cpus should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"virt_cpus"},
 			},
 			"virt_type": {
 				Description: "The type of virtual machine. Valid options are: xenpv, xenfv, qemu, kvm, vmware, openvz.",
@@ -411,6 +502,13 @@ func resourceSystem() *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Computed:    true,
+			},
+			"virt_ram_inherit": {
+				Description:   "Signal that virt_ram should be set to inherit from its parent",
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"virt_ram"},
 			},
 			"virt_disk_driver": {
 				Description: "The virtual machine disk driver.",
@@ -491,11 +589,11 @@ func resourceSystemRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	// Set all fields
-	err = d.Set("boot_files", system.BootFiles.Data)
+	err = SetInherit(d, "boot_files", system.BootFiles, make(map[string]interface{}))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("boot_loaders", system.BootLoaders.Data)
+	err = SetInherit(d, "boot_loaders", system.BootLoaders, make([]string, 0))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -504,11 +602,11 @@ func resourceSystemRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.FromErr(err)
 	}
 	// TODO: enable_ipxe
-	err = d.Set("enable_gpxe", system.EnableIPXE.Data)
+	err = SetInherit(d, "enable_gpxe", system.EnableIPXE, false)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("fetchable_files", system.FetchableFiles.Data)
+	err = SetInherit(d, "fetchable_files", system.FetchableFiles, make(map[string]interface{}))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -528,32 +626,25 @@ func resourceSystemRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("kernel_options", system.KernelOptions.Data)
+	err = SetInherit(d, "kernel_options", system.KernelOptions, make(map[string]interface{}))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("kernel_options_post", system.KernelOptionsPost.Data)
+	err = SetInherit(d, "kernel_options_post", system.KernelOptionsPost, make(map[string]interface{}))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("autoinstall_meta", system.AutoinstallMeta.Data)
+	err = SetInherit(d, "autoinstall_meta", system.AutoinstallMeta, make(map[string]interface{}))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("mgmt_classes", system.MgmtClasses.Data)
+	err = SetInherit(d, "mgmt_classes", system.MgmtClasses, make([]string, 0))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	if system.MgmtParameters.IsInherited {
-		err = d.Set("mgmt_parameters", make(map[string]interface{}))
-		if err != nil {
-			return diag.FromErr(err)
-		}
-	} else {
-		err = d.Set("mgmt_parameters", system.MgmtParameters.Data)
-		if err != nil {
-			return diag.FromErr(err)
-		}
+	err = SetInherit(d, "mgmt_parameters", system.MgmtParameters, make(map[string]interface{}))
+	if err != nil {
+		return diag.FromErr(err)
 	}
 	err = d.Set("name", system.Name)
 	if err != nil {
@@ -579,7 +670,7 @@ func resourceSystemRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("owners", system.Owners.Data)
+	err = SetInherit(d, "owners", system.Owners, make([]string, 0))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -615,21 +706,19 @@ func resourceSystemRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("template_files", system.TemplateFiles.Data)
+	err = SetInherit(d, "template_files", system.TemplateFiles, make(map[string]interface{}))
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("virt_auto_boot", system.VirtAutoBoot.Data)
+	err = SetInherit(d, "virt_auto_boot", system.VirtAutoBoot, false)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	if !system.VirtFileSize.IsInherited {
-		err = d.Set("virt_file_size", system.VirtFileSize.Data)
-		if err != nil {
-			return diag.FromErr(err)
-		}
+	err = SetInherit(d, "virt_file_size", system.VirtFileSize, 0)
+	if err != nil {
+		return diag.FromErr(err)
 	}
-	err = d.Set("virt_cpus", system.VirtCPUs.Data)
+	err = SetInherit(d, "virt_cpus", system.VirtCPUs, 0)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -645,7 +734,7 @@ func resourceSystemRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("virt_ram", system.VirtRAM.Data)
+	err = SetInherit(d, "virt_ram", system.VirtRAM, 0)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -855,21 +944,21 @@ func buildSystem(d *schema.ResourceData) (cobbler.System, error) {
 	}
 	system.BootFiles = cobbler.Value[map[string]interface{}]{
 		Data:        bootFiles,
-		IsInherited: false,
+		IsInherited: d.Get("boot_files_inherit").(bool),
 	}
 	system.BootLoaders = cobbler.Value[[]string]{
 		Data:        bootLoaders,
-		IsInherited: false,
+		IsInherited: d.Get("boot_loaders_inherit").(bool),
 	}
 	system.Comment = d.Get("comment").(string)
 	// TODO: enable_ipxe
 	system.EnableIPXE = cobbler.Value[bool]{
 		Data:        d.Get("enable_gpxe").(bool),
-		IsInherited: false,
+		IsInherited: d.Get("enable_gpxe_inherit").(bool),
 	}
 	system.FetchableFiles = cobbler.Value[map[string]interface{}]{
 		Data:        fetchableFiles,
-		IsInherited: false,
+		IsInherited: d.Get("fetchable_files_inherit").(bool),
 	}
 	system.Gateway = d.Get("gateway").(string)
 	system.Hostname = d.Get("hostname").(string)
@@ -877,19 +966,19 @@ func buildSystem(d *schema.ResourceData) (cobbler.System, error) {
 	system.IPv6DefaultDevice = d.Get("ipv6_default_device").(string)
 	system.KernelOptions = cobbler.Value[map[string]interface{}]{
 		Data:        kernelOptions,
-		IsInherited: false,
+		IsInherited: d.Get("kernel_options_inherit").(bool),
 	}
 	system.KernelOptionsPost = cobbler.Value[map[string]interface{}]{
 		Data:        kernelOptionsPost,
-		IsInherited: false,
+		IsInherited: d.Get("kernel_options_post_inherit").(bool),
 	}
 	system.MgmtClasses = cobbler.Value[[]string]{
 		Data:        mgmtClasses,
-		IsInherited: false,
+		IsInherited: d.Get("mgmt_classes_inherit").(bool),
 	}
 	system.MgmtParameters = cobbler.Value[map[string]interface{}]{
 		Data:        mgmtParameters,
-		IsInherited: false,
+		IsInherited: d.Get("mgmt_parameters_inherit").(bool),
 	}
 	system.Name = d.Get("name").(string)
 	system.NameServersSearch = nameServersSearch
@@ -899,7 +988,7 @@ func buildSystem(d *schema.ResourceData) (cobbler.System, error) {
 	system.NextServerv6 = d.Get("next_server_v6").(string)
 	system.Owners = cobbler.Value[[]string]{
 		Data:        owners,
-		IsInherited: false,
+		IsInherited: d.Get("owners_inherit").(bool),
 	}
 	system.PowerAddress = d.Get("power_address").(string)
 	system.PowerID = d.Get("power_id").(string)
@@ -911,26 +1000,26 @@ func buildSystem(d *schema.ResourceData) (cobbler.System, error) {
 	system.Status = d.Get("status").(string)
 	system.TemplateFiles = cobbler.Value[map[string]interface{}]{
 		Data:        templateFiles,
-		IsInherited: false,
+		IsInherited: d.Get("template_files_inherit").(bool),
 	}
 	system.VirtAutoBoot = cobbler.Value[bool]{
 		Data:        d.Get("virt_auto_boot").(bool),
-		IsInherited: false,
+		IsInherited: d.Get("virt_auto_boot_inherit").(bool),
 	}
 	system.VirtFileSize = cobbler.Value[float64]{
 		Data:        d.Get("virt_file_size").(float64),
-		IsInherited: false,
+		IsInherited: d.Get("virt_file_size_inherit").(bool),
 	}
 	system.VirtCPUs = cobbler.Value[int]{
 		Data:        d.Get("virt_cpus").(int),
-		IsInherited: false,
+		IsInherited: d.Get("virt_cpus_inherit").(bool),
 	}
 	system.VirtType = d.Get("virt_type").(string)
 	system.VirtPath = d.Get("virt_path").(string)
 	system.VirtPXEBoot = d.Get("virt_pxe_boot").(bool)
 	system.VirtRAM = cobbler.Value[int]{
 		Data:        d.Get("virt_ram").(int),
-		IsInherited: false,
+		IsInherited: d.Get("virt_ram_inherit").(bool),
 	}
 	system.VirtDiskDriver = d.Get("virt_disk_driver").(string)
 

--- a/cobbler/resource_cobbler_system_test.go
+++ b/cobbler/resource_cobbler_system_test.go
@@ -120,7 +120,7 @@ func testAccCobblerCheckSystemDestroy(s *terraform.State) error {
 			continue
 		}
 
-		if _, err := cobblerApiClient.GetSystem(rs.Primary.ID); err == nil {
+		if _, err := cobblerApiClient.GetSystem(rs.Primary.ID, false, false); err == nil {
 			//goland:noinspection GoErrorStringFormat
 			return fmt.Errorf("System still exists")
 		}
@@ -140,7 +140,7 @@ func testAccCobblerCheckSystemExists(n string, system *cobbler.System) resource.
 			return fmt.Errorf("no ID is set")
 		}
 
-		found, err := cobblerApiClient.GetSystem(rs.Primary.ID)
+		found, err := cobblerApiClient.GetSystem(rs.Primary.ID, false, false)
 		if err != nil {
 			return err
 		}

--- a/cobbler/utils.go
+++ b/cobbler/utils.go
@@ -3,6 +3,7 @@ package cobbler
 import (
 	"bytes"
 	"fmt"
+	cobbler "github.com/cobbler/cobblerclient"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mitchellh/go-homedir"
 	"hash/crc32"
@@ -92,4 +93,27 @@ func GetInterfaceMap(d *schema.ResourceData, key string) (map[string]interface{}
 		return nil, fmt.Errorf("key `%s` is not a map", key)
 	}
 	return interfaceData, nil
+}
+
+func SetInherit[K any](d *schema.ResourceData, key string, value cobbler.Value[K], defaultValue K) error {
+	if value.IsInherited {
+		err := d.Set(fmt.Sprintf("%s_inherit", key), value.IsInherited)
+		if err != nil {
+			return err
+		}
+		err = d.Set(key, defaultValue)
+		if err != nil {
+			return err
+		}
+	} else {
+		err := d.Set(fmt.Sprintf("%s_inherit", key), false)
+		if err != nil {
+			return err
+		}
+		err = d.Set(key, value.Data)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/cobbler/utils.go
+++ b/cobbler/utils.go
@@ -3,6 +3,7 @@ package cobbler
 import (
 	"bytes"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mitchellh/go-homedir"
 	"hash/crc32"
 	"os"
@@ -65,4 +66,30 @@ func Strings(strings []string) string {
 	}
 
 	return fmt.Sprintf("%d", String(buf.String()))
+}
+
+// GetStringSlice is a helper which safely retrieves the data of a given key and casts it to a string slice.
+func GetStringSlice(d *schema.ResourceData, key string) ([]string, error) {
+	result := make([]string, 0)
+	keyData, ok := d.Get(key).([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("key `%s` is not an array", key)
+	}
+	for _, element := range keyData {
+		var castedElement string
+		castedElement, ok = element.(string)
+		if !ok {
+			return nil, fmt.Errorf("key `%s` is not a string", key)
+		}
+		result = append(result, castedElement)
+	}
+	return result, nil
+}
+
+func GetInterfaceMap(d *schema.ResourceData, key string) (map[string]interface{}, error) {
+	interfaceData, ok := d.Get(key).(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("key `%s` is not a map", key)
+	}
+	return interfaceData, nil
 }

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   cobbler:
     image: cobbler-dev

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   cobbler:
     image: cobbler-dev
     container_name: cobbler-dev
+    privileged: true  # Required for Cobbler 3.3.2 and newer
     volumes:
       - ./cobbler_source:/code
       - ../extracted_iso_image:/extracted_iso_image

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -6,8 +6,8 @@ if [ -z "$1" ]
     echo "No cobbler server url supplied"
 fi
 
-cobbler_commit=b3b6ee2391c5a1fb89f7796e4d9dc6538617485a # master as of 4/2/2022
-cobbler_branch=master
+cobbler_commit=df356046f3cf27be62a61001b982d5983800cfd9 # 3.3.6 as of 2024-10-09
+cobbler_branch=release33
 iso_url=https://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04.1-legacy-server-amd64.iso
 iso_os=ubuntu
 valid_iso_checksum=00a9d46306fbe9beb3581853a289490bc231c51f

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -44,7 +44,7 @@ else
 fi
 
 docker build -f ./docker/cobbler_source/docker/develop/develop.dockerfile -t cobbler-dev .
-docker compose -f docker/docker-compose.yml up -d
+docker compose -f docker/compose.yml up -d
 
 SERVER_URL=$1
 printf "### Waiting for Cobbler to become available on ${SERVER_URL} \n\n"
@@ -56,7 +56,7 @@ until $(curl --connect-timeout 1 --output /dev/null --silent ${SERVER_URL}); do
   if [ ${attempt_counter} -eq ${max_attempts} ];then
     echo "Max attempts reached"
     # Debug logs
-    docker compose -f ./docker/docker-compose.yml logs
+    docker compose -f ./docker/compose.yml logs
     exit 1
   fi
 
@@ -67,4 +67,4 @@ done
 # Sleep 10 seconds to let the "cobbler import" succeed
 sleep 10
 
-docker compose -f docker/docker-compose.yml logs
+docker compose -f docker/compose.yml logs

--- a/docs/resources/distro.md
+++ b/docs/resources/distro.md
@@ -38,14 +38,22 @@ resource "cobbler_distro" "Ubuntu-2004-x86_64" {
 
 - `arch` (String) The architecture of the distro. Valid options are: i386, x86_64, ia64, ppc, ppc64, s390, arm.
 - `boot_files` (Map of String) Files copied into tftpboot beyond the kernel/initrd.
+- `boot_files_inherit` (Boolean) Signal that boot_files should be set to inherit from its parent
 - `boot_loaders` (List of String) Must be either 'grub', 'pxe', or 'ipxe'.
+- `boot_loaders_inherit` (Boolean) Signal that boot_loaders should be set to inherit from its parent
 - `comment` (String) Free form text description.
 - `fetchable_files` (Map of String) Templates for tftp or wget.
+- `fetchable_files_inherit` (Boolean) Signal that fetchable_files should be set to inherit from its parent
 - `kernel_options` (Map of String) Kernel options to use with the kernel.
+- `kernel_options_inherit` (Boolean) Signal that kernel_options should be set to inherit from its parent
 - `kernel_options_post` (Map of String) Post install Kernel options to use with the kernel after installation.
+- `kernel_options_post_inherit` (Boolean) Signal that kernel_options_post should be set to inherit from its parent
 - `mgmt_classes` (List of String) Management classes for external config management.
+- `mgmt_classes_inherit` (Boolean) Signal that mgmt_classes should be set to inherit from its parent
 - `owners` (List of String) Owners list for authz_ownership.
+- `owners_inherit` (Boolean) Signal that owners should be set to inherit from its parent
 - `template_files` (Map of String) File mappings for built-in config management.
+- `template_files_inherit` (Boolean) Signal that template_files should be set to inherit from its parent
 
 ### Read-Only
 

--- a/docs/resources/distro.md
+++ b/docs/resources/distro.md
@@ -37,15 +37,15 @@ resource "cobbler_distro" "Ubuntu-2004-x86_64" {
 ### Optional
 
 - `arch` (String) The architecture of the distro. Valid options are: i386, x86_64, ia64, ppc, ppc64, s390, arm.
-- `boot_files` (List of String) Files copied into tftpboot beyond the kernel/initrd.
+- `boot_files` (Map of String) Files copied into tftpboot beyond the kernel/initrd.
 - `boot_loaders` (List of String) Must be either 'grub', 'pxe', or 'ipxe'.
 - `comment` (String) Free form text description.
-- `fetchable_files` (List of String) Templates for tftp or wget.
-- `kernel_options` (List of String) Kernel options to use with the kernel.
-- `kernel_options_post` (List of String) Post install Kernel options to use with the kernel after installation.
+- `fetchable_files` (Map of String) Templates for tftp or wget.
+- `kernel_options` (Map of String) Kernel options to use with the kernel.
+- `kernel_options_post` (Map of String) Post install Kernel options to use with the kernel after installation.
 - `mgmt_classes` (List of String) Management classes for external config management.
 - `owners` (List of String) Owners list for authz_ownership.
-- `template_files` (List of String) File mappings for built-in config management.
+- `template_files` (Map of String) File mappings for built-in config management.
 
 ### Read-Only
 

--- a/docs/resources/profile.md
+++ b/docs/resources/profile.md
@@ -32,33 +32,49 @@ resource "cobbler_profile" "my_profile" {
 
 - `autoinstall` (String) Template remote kickstarts or preseeds.
 - `autoinstall_meta` (Map of String) Automatic installation template metadata, formerly Kickstart metadata.
+- `autoinstall_meta_inherit` (Boolean) Signal that autoinstall_meta should be set to inherit from its parent
 - `boot_files` (Map of String) Files copied into tftpboot beyond the kernel/initrd.
+- `boot_files_inherit` (Boolean) Signal that boot_files should be set to inherit from its parent
 - `comment` (String) Free form text description.
 - `dhcp_tag` (String) DHCP tag.
-- `enable_gpxe` (Boolean) Use gPXE instead of PXELINUX for advanced booting options.
+- `enable_ipxe` (Boolean) Use iPXE instead of PXELINUX for advanced booting options.
+- `enable_ipxe_inherit` (Boolean) Signal that enable_ipxe should be set to inherit from its parent
 - `enable_menu` (Boolean) Enable a boot menu.
+- `enable_menu_inherit` (Boolean) Signal that enable_menu should be set to inherit from its parent
 - `fetchable_files` (Map of String) Templates for tftp or wget.
+- `fetchable_files_inherit` (Boolean) Signal that fetchable_files should be set to inherit from its parent
 - `kernel_options` (Map of String) Kernel options for the profile.
+- `kernel_options_inherit` (Boolean) Signal that kernel_options should be set to inherit from its parent
 - `kernel_options_post` (Map of String) Post install kernel options.
+- `kernel_options_post_inherit` (Boolean) Signal that kernel_options_post should be set to inherit from its parent
 - `mgmt_classes` (List of String) For external configuration management.
+- `mgmt_classes_inherit` (Boolean) Signal that mgmt_classes should be set to inherit from its parent
 - `mgmt_parameters` (Map of String) Parameters which will be handed to your management application (Must be a valid YAML dictionary).
+- `mgmt_parameters_inherit` (Boolean) Signal that mgmt_parameters should be set to inherit from its parent
 - `name_servers` (List of String) Name servers.
+- `name_servers_inherit` (Boolean) Signal that name_servers should be set to inherit from its parent
 - `name_servers_search` (List of String) Name server search settings.
+- `name_servers_search_inherit` (Boolean) Signal that name_servers_search should be set to inherit from its parent
 - `next_server_v4` (String) The next_server_v4 option is used for DHCP/PXE as the IP of the TFTP server from which network boot files are downloaded. Usually, this will be the same IP as the server setting.
 - `next_server_v6` (String) The next_server_v6 option is used for DHCP/PXE as the IP of the TFTP server from which network boot files are downloaded. Usually, this will be the same IP as the server setting.
 - `owners` (List of String) Owners list for authz_ownership.
+- `owners_inherit` (Boolean) Signal that owners should be set to inherit from its parent
 - `parent` (String) The parent this profile inherits settings from.
 - `proxy` (String) Proxy URL.
 - `repos` (List of String) Repos to auto-assign to this profile.
 - `server` (String) The server-override for the profile.
 - `template_files` (Map of String) File mappings for built-in config management.
+- `template_files_inherit` (Boolean) Signal that template_files should be set to inherit from its parent
 - `virt_auto_boot` (Boolean) Auto boot virtual machines.
+- `virt_auto_boot_inherit` (Boolean) Signal that virt_auto_boot should be set to inherit from its parent
 - `virt_bridge` (String) The bridge for virtual machines.
 - `virt_cpus` (Number) The number of virtual CPUs
 - `virt_disk_driver` (String) The virtual machine disk driver.
 - `virt_file_size` (Number) The virtual machine file size.
+- `virt_file_size_inherit` (Boolean) Signal that virt_file_size should be set to inherit from its parent
 - `virt_path` (String) The virtual machine path.
 - `virt_ram` (Number) The amount of RAM for the virtual machine.
+- `virt_ram_inherit` (Boolean) Signal that virt_ram should be set to inherit from its parent
 - `virt_type` (String) The type of virtual machine. Valid options are: xenpv, xenfv, qemu, kvm, vmware, openvz.
 
 ### Read-Only

--- a/docs/resources/profile.md
+++ b/docs/resources/profile.md
@@ -31,17 +31,17 @@ resource "cobbler_profile" "my_profile" {
 ### Optional
 
 - `autoinstall` (String) Template remote kickstarts or preseeds.
-- `autoinstall_meta` (List of String) Automatic installation template metadata, formerly Kickstart metadata.
-- `boot_files` (List of String) Files copied into tftpboot beyond the kernel/initrd.
+- `autoinstall_meta` (Map of String) Automatic installation template metadata, formerly Kickstart metadata.
+- `boot_files` (Map of String) Files copied into tftpboot beyond the kernel/initrd.
 - `comment` (String) Free form text description.
 - `dhcp_tag` (String) DHCP tag.
 - `enable_gpxe` (Boolean) Use gPXE instead of PXELINUX for advanced booting options.
 - `enable_menu` (Boolean) Enable a boot menu.
-- `fetchable_files` (List of String) Templates for tftp or wget.
-- `kernel_options` (List of String) Kernel options for the profile.
-- `kernel_options_post` (List of String) Post install kernel options.
+- `fetchable_files` (Map of String) Templates for tftp or wget.
+- `kernel_options` (Map of String) Kernel options for the profile.
+- `kernel_options_post` (Map of String) Post install kernel options.
 - `mgmt_classes` (List of String) For external configuration management.
-- `mgmt_parameters` (String) Parameters which will be handed to your management application (Must be a valid YAML dictionary).
+- `mgmt_parameters` (Map of String) Parameters which will be handed to your management application (Must be a valid YAML dictionary).
 - `name_servers` (List of String) Name servers.
 - `name_servers_search` (List of String) Name server search settings.
 - `next_server_v4` (String) The next_server_v4 option is used for DHCP/PXE as the IP of the TFTP server from which network boot files are downloaded. Usually, this will be the same IP as the server setting.
@@ -51,14 +51,14 @@ resource "cobbler_profile" "my_profile" {
 - `proxy` (String) Proxy URL.
 - `repos` (List of String) Repos to auto-assign to this profile.
 - `server` (String) The server-override for the profile.
-- `template_files` (List of String) File mappings for built-in config management.
-- `virt_auto_boot` (String) Auto boot virtual machines.
+- `template_files` (Map of String) File mappings for built-in config management.
+- `virt_auto_boot` (Boolean) Auto boot virtual machines.
 - `virt_bridge` (String) The bridge for virtual machines.
-- `virt_cpus` (String) The number of virtual CPUs
+- `virt_cpus` (Number) The number of virtual CPUs
 - `virt_disk_driver` (String) The virtual machine disk driver.
-- `virt_file_size` (String) The virtual machine file size.
+- `virt_file_size` (Number) The virtual machine file size.
 - `virt_path` (String) The virtual machine path.
-- `virt_ram` (String) The amount of RAM for the virtual machine.
+- `virt_ram` (Number) The amount of RAM for the virtual machine.
 - `virt_type` (String) The type of virtual machine. Valid options are: xenpv, xenfv, qemu, kvm, vmware, openvz.
 
 ### Read-Only

--- a/docs/resources/repo.md
+++ b/docs/resources/repo.md
@@ -39,11 +39,14 @@ resource "cobbler_repo" "my_repo" {
 - `arch` (String) The architecture of the repo. Valid options are: i386, x86_64, ia64, ppc, ppc64, s390, arm.
 - `comment` (String) Free form text description.
 - `createrepo_flags` (String) Flags to use with `createrepo`.
+- `createrepo_flags_inherit` (Boolean) Signal that createrepo_flags should be set to inherit from its parent
 - `environment` (String) Environment variables to use during repo command execution.
 - `keep_updated` (Boolean) Update the repo upon Cobbler sync. Valid values are true or false.
 - `mirror_locally` (Boolean) Whether to copy the files locally or just references to the external files. Valid values are true or false.
 - `owners` (List of String) List of Owners for authz_ownership.
+- `owners_inherit` (Boolean) Signal that owners should be set to inherit from its parent
 - `proxy` (String) Proxy to use for downloading the repo. This argument does not work on older versions of Cobbler.
+- `proxy_inherit` (Boolean) Signal that proxy should be set to inherit from its parent
 - `rpm_list` (List of String) List of specific RPMs to mirror.
 
 ### Read-Only

--- a/docs/resources/system.md
+++ b/docs/resources/system.md
@@ -49,26 +49,36 @@ resource "cobbler_system" "my_system" {
 
 - `autoinstall` (String) Template remote kickstarts or preseeds.
 - `autoinstall_meta` (Map of String) Automatic installation template metadata, formerly Kickstart metadata.
+- `autoinstall_meta_inherit` (Boolean) Signal that autoinstall_meta should be set to inherit from its parent
 - `boot_files` (Map of String) Files copied into tftpboot beyond the kernel/initrd.
+- `boot_files_inherit` (Boolean) Signal that boot_files should be set to inherit from its parent
 - `boot_loaders` (List of String) Must be either `grub`, `pxe`, or `ipxe`.
+- `boot_loaders_inherit` (Boolean) Signal that boot_loaders should be set to inherit from its parent
 - `comment` (String) Free form text description.
-- `enable_gpxe` (Boolean) Use gPXE instead of PXELINUX for advanced booting options.
+- `enable_ipxe` (Boolean) Use iPXE instead of PXELINUX for advanced booting options.
+- `enable_ipxe_inherit` (Boolean) Signal that enable_ipxe should be set to inherit from its parent
 - `fetchable_files` (Map of String) Templates for tftp or wget.
+- `fetchable_files_inherit` (Boolean) Signal that fetchable_files should be set to inherit from its parent
 - `gateway` (String) Network gateway.
 - `hostname` (String) Hostname of the system.
 - `image` (String) Parent image (if no profile is used).
 - `interface` (Block Set) The `interface` Block Set. (see [below for nested schema](#nestedblock--interface))
 - `ipv6_default_device` (String) IPv6 default device.
 - `kernel_options` (Map of String) Kernel options. ex: `selinux=permissive`.
+- `kernel_options_inherit` (Boolean) Signal that kernel_options should be set to inherit from its parent
 - `kernel_options_post` (Map of String) Kernel options (post install).
+- `kernel_options_post_inherit` (Boolean) Signal that kernel_options_post should be set to inherit from its parent
 - `mgmt_classes` (List of String) For external configuration management.
+- `mgmt_classes_inherit` (Boolean) Signal that mgmt_classes should be set to inherit from its parent
 - `mgmt_parameters` (Map of String) Parameters which will be handed to your management application (Must be a valid YAML dictionary).
+- `mgmt_parameters_inherit` (Boolean) Signal that mgmt_parameters should be set to inherit from its parent
 - `name_servers` (List of String) Name servers.
 - `name_servers_search` (List of String) Name server search settings.
 - `netboot_enabled` (Boolean) (Re)install this machine at next boot.
 - `next_server_v4` (String) The next_server_v4 option is used for DHCP/PXE as the IP of the TFTP server from which network boot files are downloaded. Usually, this will be the same IP as the server setting.
 - `next_server_v6` (String) The next_server_v6 option is used for DHCP/PXE as the IP of the TFTP server from which network boot files are downloaded. Usually, this will be the same IP as the server setting.
 - `owners` (List of String) Owners list for authz_ownership.
+- `owners_inherit` (Boolean) Signal that owners should be set to inherit from its parent
 - `power_address` (String) Power management address.
 - `power_id` (String) Usually a plug number or blade name if power type requires it.
 - `power_pass` (String) Power management password.
@@ -77,13 +87,18 @@ resource "cobbler_system" "my_system" {
 - `proxy` (String) Proxy URL.
 - `status` (String) System status (development, testing, acceptance, production).
 - `template_files` (Map of String) File mappings for built-in config management.
+- `template_files_inherit` (Boolean) Signal that template_files should be set to inherit from its parent
 - `virt_auto_boot` (Boolean) Auto boot virtual machines.
+- `virt_auto_boot_inherit` (Boolean) Signal that virt_auto_boot should be set to inherit from its parent
 - `virt_cpus` (Number) The number of virtual CPUs
+- `virt_cpus_inherit` (Boolean) Signal that virt_cpus should be set to inherit from its parent
 - `virt_disk_driver` (String) The virtual machine disk driver.
 - `virt_file_size` (Number) The virtual machine file size.
+- `virt_file_size_inherit` (Boolean) Signal that virt_file_size should be set to inherit from its parent
 - `virt_path` (String) The virtual machine path.
 - `virt_pxe_boot` (Boolean) Use PXE to build this virtual machine.
 - `virt_ram` (Number) The amount of RAM for the virtual machine.
+- `virt_ram_inherit` (Boolean) Signal that virt_ram should be set to inherit from its parent
 - `virt_type` (String) The type of virtual machine. Valid options are: xenpv, xenfv, qemu, kvm, vmware, openvz.
 
 ### Read-Only

--- a/docs/resources/system.md
+++ b/docs/resources/system.md
@@ -48,21 +48,21 @@ resource "cobbler_system" "my_system" {
 ### Optional
 
 - `autoinstall` (String) Template remote kickstarts or preseeds.
-- `autoinstall_meta` (List of String) Automatic installation template metadata, formerly Kickstart metadata.
-- `boot_files` (String) Files copied into tftpboot beyond the kernel/initrd.
+- `autoinstall_meta` (Map of String) Automatic installation template metadata, formerly Kickstart metadata.
+- `boot_files` (Map of String) Files copied into tftpboot beyond the kernel/initrd.
 - `boot_loaders` (List of String) Must be either `grub`, `pxe`, or `ipxe`.
 - `comment` (String) Free form text description.
 - `enable_gpxe` (Boolean) Use gPXE instead of PXELINUX for advanced booting options.
-- `fetchable_files` (List of String) Templates for tftp or wget.
+- `fetchable_files` (Map of String) Templates for tftp or wget.
 - `gateway` (String) Network gateway.
 - `hostname` (String) Hostname of the system.
 - `image` (String) Parent image (if no profile is used).
 - `interface` (Block Set) The `interface` Block Set. (see [below for nested schema](#nestedblock--interface))
 - `ipv6_default_device` (String) IPv6 default device.
-- `kernel_options` (List of String) Kernel options. ex: `selinux=permissive`.
-- `kernel_options_post` (List of String) Kernel options (post install).
+- `kernel_options` (Map of String) Kernel options. ex: `selinux=permissive`.
+- `kernel_options_post` (Map of String) Kernel options (post install).
 - `mgmt_classes` (List of String) For external configuration management.
-- `mgmt_parameters` (String) Parameters which will be handed to your management application (Must be a valid YAML dictionary).
+- `mgmt_parameters` (Map of String) Parameters which will be handed to your management application (Must be a valid YAML dictionary).
 - `name_servers` (List of String) Name servers.
 - `name_servers_search` (List of String) Name server search settings.
 - `netboot_enabled` (Boolean) (Re)install this machine at next boot.
@@ -76,14 +76,14 @@ resource "cobbler_system" "my_system" {
 - `power_user` (String) Power management user.
 - `proxy` (String) Proxy URL.
 - `status` (String) System status (development, testing, acceptance, production).
-- `template_files` (List of String) File mappings for built-in config management.
-- `virt_auto_boot` (String) Auto boot virtual machines.
-- `virt_cpus` (String) The number of virtual CPUs
+- `template_files` (Map of String) File mappings for built-in config management.
+- `virt_auto_boot` (Boolean) Auto boot virtual machines.
+- `virt_cpus` (Number) The number of virtual CPUs
 - `virt_disk_driver` (String) The virtual machine disk driver.
-- `virt_file_size` (String) The virtual machine file size.
+- `virt_file_size` (Number) The virtual machine file size.
 - `virt_path` (String) The virtual machine path.
-- `virt_pxe_boot` (Number) Use PXE to build this virtual machine.
-- `virt_ram` (String) The amount of RAM for the virtual machine.
+- `virt_pxe_boot` (Boolean) Use PXE to build this virtual machine.
+- `virt_ram` (Number) The amount of RAM for the virtual machine.
 - `virt_type` (String) The type of virtual machine. Valid options are: xenpv, xenfv, qemu, kvm, vmware, openvz.
 
 ### Read-Only

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cobbler/terraform-provider-cobbler
 go 1.22
 
 require (
-	github.com/cobbler/cobblerclient v0.4.3
+	github.com/cobbler/cobblerclient v0.5.3
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.10.0
 )
@@ -12,6 +12,8 @@ require (
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.2 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
+	github.com/go-test/deep v1.1.1 // indirect
+	github.com/go-viper/mapstructure/v2 v2.0.0 // indirect
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/hc-install v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
-github.com/ContainerSolutions/go-utils v0.1.0 h1:cjCek/u3qVUSDejTqdSNQFummm9W/OUR7yfzplTaDN0=
-github.com/ContainerSolutions/go-utils v0.1.0/go.mod h1:kwETtmd5o1Ih1kSnvyZ5CPBNREDObipu4e0zWF3Vo8g=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=
@@ -15,8 +13,8 @@ github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZ
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
-github.com/cobbler/cobblerclient v0.4.3 h1:dGjcayCorEB0WUk4l3xa11rtRuJjyG4SdOG6qWk+jtI=
-github.com/cobbler/cobblerclient v0.4.3/go.mod h1:fjhmlYZN/VqHVmphwQiRpB/aNFsAVRQzB52ioASnoxg=
+github.com/cobbler/cobblerclient v0.5.3 h1:43STm8izD++BqHJIpxpYrHvNXXQvCtmcmlyO2gskNmg=
+github.com/cobbler/cobblerclient v0.5.3/go.mod h1:n6b8fTUOlg7BdMl6FeifUm4Uk1JY6/tlTlOClV4x2Wc=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -35,8 +33,10 @@ github.com/go-git/go-billy/v5 v5.5.0 h1:yEY4yhzCDuMGSv83oGxiBotRzhwhNr8VZyphhiu+
 github.com/go-git/go-billy/v5 v5.5.0/go.mod h1:hmexnoNsr2SJU1Ju67OaNz5ASJY3+sHgFRpCtpDCKow=
 github.com/go-git/go-git/v5 v5.12.0 h1:7Md+ndsjrzZxbddRDZjF14qK+NN56sy6wkqaVrjZtys=
 github.com/go-git/go-git/v5 v5.12.0/go.mod h1:FTM9VKtnI2m65hNI/TenDDDnUf2Q9FHnXYjuz9i5OEY=
-github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
-github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
+github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
+github.com/go-viper/mapstructure/v2 v2.0.0 h1:dhn8MZ1gZ0mzeodTG3jt5Vj/o87xZKuNAprG2mQfMfc=
+github.com/go-viper/mapstructure/v2 v2.0.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -125,7 +125,6 @@ github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJ
 github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
-github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=


### PR DESCRIPTION
## Linked Items

Fixes #39

Fixes #40 

## Description

This PR updates the cobblerclient to 0.5.3 and ensures that the terraform provider can handle all Cobbler versions that are in the 3.3.x release series.

## Behaviour changes

Old: The provider crashes once used with more recent versions of Cobbler.

New: The provider works with all 3.3.x Cobbler versions.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [x] Code is already covered by System-Tests
- [ ] No tests required
