### PR TITLE
CI: Add coverage upload

### DIFF
--- a/.github/workflows/coverage-upload.yml
+++ b/.github/workflows/coverage-upload.yml
@@ -1,0 +1,55 @@
+name: Coverage Upload
+
+on:
+  workflow_run:
+    workflows: [testing]
+    types:
+      - completed
+
+jobs:
+  run_tests:
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/github-script
+      # Based on: https://github.com/orgs/community/discussions/34652
+      - name: 'Download artifact'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "coverage-report"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/coverage-report.zip`, Buffer.from(download.data));
+      - name: 'Unzip artifact'
+        run: unzip coverage-report.zip
+      # https://github.com/actions/download-artifact
+      # - name: Download artifact
+      #   id: download-artifact
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     run-id: ${{ github.event.workflow_run.id }}
+      # https://github.com/codacy/codacy-coverage-reporter-action
+      # - name: Run codacy-coverage-reporter
+      #   uses: codacy/codacy-coverage-reporter-action@v1
+      #   with:
+      #     project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+      #     coverage-reports: coverage.xml
+      - name: Publish Code Coverage Results
+        run: |
+          auth="--project-token ${{ secrets.CODACY_PROJECT_TOKEN }}"
+          commit_uuid="--commit-uuid ${{ github.event.workflow_run.head_sha }}"
+
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report $auth $commit_uuid -r coverage.out --partial &&\
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) final $auth $commit_uuid

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -94,3 +94,11 @@ jobs:
           path: |
             *.iso
           key: ${{ steps.cache-iso-restore.outputs.cache-primary-key }}
+      # https://github.com/actions/upload-artifact
+      - name: Upload coverage report to GH artifacts
+        if: matrix.cobbler_version == 'df356046f3cf27be62a61001b982d5983800cfd9'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.out
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ vendor/
 docker/cobbler_source/
 extracted_iso_image/
 *.iso
+coverage.out

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,7 +23,7 @@ test: fmtcheck
 .PHONY: testacc
 testacc:
 	@COBBLER_VERSION=v3.3.0 sh -c "'./docker/start.sh' $(COBBLER_SERVER_URL)"
-	TF_LOG=TRACE TF_ACC_LOG=TRACE TF_LOG_PATH_MASK="test-%s.log" TF_ACC=1 COBBLER_URL=$(COBBLER_SERVER_URL) COBBLER_USERNAME=cobbler COBBLER_PASSWORD=cobbler go test -v -cover $(TEST)
+	TF_LOG=TRACE TF_ACC_LOG=TRACE TF_LOG_PATH_MASK="test-%s.log" TF_ACC=1 COBBLER_URL=$(COBBLER_SERVER_URL) COBBLER_USERNAME=cobbler COBBLER_PASSWORD=cobbler go test -v -coverprofile="coverage.out" -covermode="atomic" $(TEST)
 
 vet:
 	@echo "go vet ."

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cobbler Terraform Provider
 
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/d68c9aff2cd74b69afc9366ab4415f6a)](https://app.codacy.com/gh/cobbler/terraform-provider-cobbler/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+
 The Cobbler provider is used to interact with a locally installed Cobbler service.\
 The provider needs to be configured with the proper credentials before it can be used.
 


### PR DESCRIPTION
## Linked Items

Fixes #44

## Description

This PR adds coverage upload to Codacy via the split mechanism that the backend repository uses. This ensures that even coverage uploads from forks are successful.

## Behaviour changes

Old: Coverage is not collected

New: Coverage is collected and uploaded to Codacy.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required
