### PR TITLE
CI: Force golang parser

### DIFF
--- a/.github/workflows/coverage-upload.yml
+++ b/.github/workflows/coverage-upload.yml
@@ -51,5 +51,5 @@ jobs:
           auth="--project-token ${{ secrets.CODACY_PROJECT_TOKEN }}"
           commit_uuid="--commit-uuid ${{ github.event.workflow_run.head_sha }}"
 
-          bash <(curl -Ls https://coverage.codacy.com/get.sh) report $auth $commit_uuid -r coverage.out --partial &&\
+          bash <(curl -Ls https://coverage.codacy.com/get.sh) report $auth $commit_uuid --force-coverage-parser go -r coverage.out --partial &&\
           bash <(curl -Ls https://coverage.codacy.com/get.sh) final $auth $commit_uuid


### PR DESCRIPTION
## Linked Items

No bugreport

## Description

Fixes an issue with the CI that scala is detected by Codacy.

```
2024-10-16 08:52:45.018Z  info [ConfigurationRules] API base URL: https://api.codacy.com/  - (ConfigurationRules.scala:81)
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
2024-10-16 08:52:45.019Z  info [ReportRules] Parsing coverage data from: /home/runner/work/terraform-provider-cobbler/terraform-provider-cobbler/coverage.out ...  - (ReportRules.scala:41)
2024-10-16 08:52:45.024Z  info [ReportRules] Coverage parser used is com.codacy.parsers.implementation.LCOVParser$@3ce4d9da  - (ReportRules.scala:46)
2024-10-16 08:52:45.024Z  warn [ReportRules] Report files will not be matched against git files, reason: Could not retrieve files from local Git directory, error message: java.lang.InstantiationException: org.eclipse.jgit.internal.JGitText  - (ReportRules.scala:334)
2024-10-16 08:52:45.024Z  warn [ReportRules] The generated coverage report /home/runner/work/terraform-provider-cobbler/terraform-provider-cobbler/coverage.out is empty or contains no data for repository files.  - (ReportRules.scala:59)
2024-10-16 08:52:45.024Z  info [ReportRules] 
To complete the reporting process, call coverage-reporter with the final flag.
 Check https://docs.codacy.com/coverage-reporter/#multiple-reports
 for more information.  - (ReportRules.scala:88)
2024-10-16 08:52:45.024Z error [CodacyCoverageReporter] No coverage data was sent  - (CodacyCoverageReporter.scala:28)
```

## Behaviour changes

Old: <!-- This is the old way Cobbler behaved -->

New: <!-- This is the new way Cobbler behaves -->

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required
