### PR TITLE
Add support for "terraform import"

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -25,6 +25,10 @@ testacc:
 	@COBBLER_VERSION=v3.3.0 sh -c "'./docker/start.sh' $(COBBLER_SERVER_URL)"
 	TF_LOG=TRACE TF_ACC_LOG=TRACE TF_LOG_PATH_MASK="test-%s.log" TF_ACC=1 COBBLER_URL=$(COBBLER_SERVER_URL) COBBLER_USERNAME=cobbler COBBLER_PASSWORD=cobbler go test -v -coverprofile="coverage.out" -covermode="atomic" $(TEST)
 
+.PHONY: docs
+docs:
+	@tfplugindocs
+
 vet:
 	@echo "go vet ."
 	@go vet $$(go list ./... | grep -v vendor/) ; if [ $$? -eq 1 ]; then \

--- a/cobbler/resource_cobbler_distro.go
+++ b/cobbler/resource_cobbler_distro.go
@@ -16,6 +16,9 @@ func resourceDistro() *schema.Resource {
 		ReadContext:   resourceDistroRead,
 		UpdateContext: resourceDistroUpdate,
 		DeleteContext: resourceDistroDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"arch": {
@@ -206,6 +209,10 @@ func resourceDistroRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	// Set all fields
+	err = d.Set("name", distro.Name)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	err = d.Set("arch", distro.Arch)
 	if err != nil {
 		return diag.FromErr(err)

--- a/cobbler/resource_cobbler_distro_test.go
+++ b/cobbler/resource_cobbler_distro_test.go
@@ -22,6 +22,11 @@ func TestAccCobblerDistro_basic(t *testing.T) {
 					testAccCobblerCheckDistroExists("cobbler_distro.foo", &distro),
 				),
 			},
+			{
+				ResourceName:      "cobbler_distro.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -39,6 +44,11 @@ func TestAccCobblerDistro_basic_inherit(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCobblerCheckDistroExists("cobbler_distro.foo", &distro),
 				),
+			},
+			{
+				ResourceName:      "cobbler_distro.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -64,6 +74,11 @@ func TestAccCobblerDistro_basic_inheritConcrete(t *testing.T) {
 					testAccCobblerCheckDistroExists("cobbler_distro.foo", &distro),
 				),
 			},
+			{
+				ResourceName:      "cobbler_distro.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -87,6 +102,11 @@ func TestAccCobblerDistro_change(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCobblerCheckDistroExists("cobbler_distro.foo", &distro),
 				),
+			},
+			{
+				ResourceName:      "cobbler_distro.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/cobbler/resource_cobbler_profile.go
+++ b/cobbler/resource_cobbler_profile.go
@@ -16,6 +16,9 @@ func resourceProfile() *schema.Resource {
 		ReadContext:   resourceProfileRead,
 		UpdateContext: resourceProfileUpdate,
 		DeleteContext: resourceProfileDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"autoinstall": {

--- a/cobbler/resource_cobbler_profile_test.go
+++ b/cobbler/resource_cobbler_profile_test.go
@@ -24,6 +24,11 @@ func TestAccCobblerProfile_basic(t *testing.T) {
 					testAccCobblerCheckProfileExists("cobbler_profile.foo", &profile),
 				),
 			},
+			{
+				ResourceName:      "cobbler_profile.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -51,6 +56,11 @@ func TestAccCobblerProfile_change(t *testing.T) {
 					testAccCobblerCheckProfileExists("cobbler_profile.foo", &profile),
 				),
 			},
+			{
+				ResourceName:      "cobbler_profile.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -70,6 +80,11 @@ func TestAccCobblerProfile_withRepo(t *testing.T) {
 					testAccCobblerCheckDistroExists("cobbler_distro.foo", &distro),
 					testAccCobblerCheckProfileExists("cobbler_profile.foo", &profile),
 				),
+			},
+			{
+				ResourceName:      "cobbler_profile.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/cobbler/resource_cobbler_repo.go
+++ b/cobbler/resource_cobbler_repo.go
@@ -16,6 +16,9 @@ func resourceRepo() *schema.Resource {
 		ReadContext:   resourceRepoRead,
 		UpdateContext: resourceRepoUpdate,
 		DeleteContext: resourceRepoDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"apt_components": {

--- a/cobbler/resource_cobbler_repo_test.go
+++ b/cobbler/resource_cobbler_repo_test.go
@@ -24,6 +24,11 @@ func TestAccCobblerRepo_basic(t *testing.T) {
 					testAccCobblerCheckRepoExists("cobbler_repo.foo", &repo),
 				),
 			},
+			{
+				ResourceName:      "cobbler_repo.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -47,6 +52,11 @@ func TestAccCobblerRepo_change(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCobblerCheckRepoExists("cobbler_repo.foo", &repo),
 				),
+			},
+			{
+				ResourceName:      "cobbler_repo.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/cobbler/resource_cobbler_snippet.go
+++ b/cobbler/resource_cobbler_snippet.go
@@ -16,6 +16,9 @@ func resourceSnippet() *schema.Resource {
 		ReadContext:   resourceSnippetRead,
 		UpdateContext: resourceSnippetUpdate,
 		DeleteContext: resourceSnippetDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -55,8 +58,20 @@ func resourceSnippetCreate(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func resourceSnippetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// Since all attributes are required and not computed,
-	// there's no reason to read.
+	config := meta.(*Config)
+
+	snippet, err := config.cobblerClient.GetSnippet(d.Id())
+	if err != nil {
+		return diag.Errorf("Cobbler TemplateFile: Error Reading: %s", err)
+	}
+	err = d.Set("name", snippet.Name)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set("body", snippet.Body)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	return nil
 }
 

--- a/cobbler/resource_cobbler_snippet_test.go
+++ b/cobbler/resource_cobbler_snippet_test.go
@@ -24,6 +24,11 @@ func TestAccCobblerSnippet_basic(t *testing.T) {
 					testAccCobblerCheckSnippetExists("cobbler_snippet.foo", &snippet),
 				),
 			},
+			{
+				ResourceName:      "cobbler_snippet.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/cobbler/resource_cobbler_system.go
+++ b/cobbler/resource_cobbler_system.go
@@ -25,6 +25,9 @@ func resourceSystem() *schema.Resource {
 		ReadContext:   resourceSystemRead,
 		UpdateContext: resourceSystemUpdate,
 		DeleteContext: resourceSystemDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"autoinstall": {

--- a/cobbler/resource_cobbler_system_test.go
+++ b/cobbler/resource_cobbler_system_test.go
@@ -28,6 +28,11 @@ func TestAccCobblerSystem_basic(t *testing.T) {
 					testAccCobblerCheckSystemExists("cobbler_system.foo", &system),
 				),
 			},
+			{
+				ResourceName:      "cobbler_system.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -49,6 +54,13 @@ func TestAccCobblerSystem_multi(t *testing.T) {
 					testAccCobblerCheckProfileExists("cobbler_profile.foo", &profile),
 					testAccCobblerCheckSystemExists("cobbler_system.foo.45", &system),
 				),
+			},
+			{
+				ResourceName:            "cobbler_system.foo[45]",
+				ImportState:             true,
+				ImportStateId:           "foo-44",
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"interface_type"},
 			},
 		},
 	})
@@ -80,6 +92,11 @@ func TestAccCobblerSystem_change(t *testing.T) {
 					testAccCobblerCheckSystemExists("cobbler_system.foo", &system),
 				),
 			},
+			{
+				ResourceName:      "cobbler_system.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -109,6 +126,12 @@ func TestAccCobblerSystem_removeInterface(t *testing.T) {
 					testAccCobblerCheckProfileExists("cobbler_profile.foo", &profile),
 					testAccCobblerCheckSystemExists("cobbler_system.foo", &system),
 				),
+			},
+			{
+				ResourceName:            "cobbler_system.foo",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"interface.0.interface_type", "interface.1.interface_type"},
 			},
 		},
 	})

--- a/cobbler/resource_cobbler_template_file.go
+++ b/cobbler/resource_cobbler_template_file.go
@@ -16,6 +16,9 @@ func resourceTemplateFile() *schema.Resource {
 		ReadContext:   resourceTemplateFileRead,
 		UpdateContext: resourceTemplateFileUpdate,
 		DeleteContext: resourceTemplateFileDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -55,7 +58,20 @@ func resourceTemplateFileCreate(ctx context.Context, d *schema.ResourceData, met
 }
 
 func resourceTemplateFileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	// Since all attributes are required and not computed, there's no reason to read.
+	config := meta.(*Config)
+
+	templateFile, err := config.cobblerClient.GetTemplateFile(d.Id())
+	if err != nil {
+		return diag.Errorf("Cobbler TemplateFile: Error Reading: %s", err)
+	}
+	err = d.Set("name", templateFile.Name)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set("body", templateFile.Body)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	return nil
 }
 

--- a/cobbler/resource_cobbler_template_file_test.go
+++ b/cobbler/resource_cobbler_template_file_test.go
@@ -24,6 +24,11 @@ func TestAccCobblerTemplateFile_basic(t *testing.T) {
 					testAccCobblerCheckTemplateFileExists("cobbler_template_file.foo", &ks),
 				),
 			},
+			{
+				ResourceName:      "cobbler_template_file.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/docs/resources/distro.md
+++ b/docs/resources/distro.md
@@ -58,3 +58,11 @@ resource "cobbler_distro" "Ubuntu-2004-x86_64" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import cobbler_distro.foo foo
+```

--- a/docs/resources/profile.md
+++ b/docs/resources/profile.md
@@ -80,3 +80,11 @@ resource "cobbler_profile" "my_profile" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import cobbler_profile.foo foo
+```

--- a/docs/resources/repo.md
+++ b/docs/resources/repo.md
@@ -52,3 +52,11 @@ resource "cobbler_repo" "my_repo" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import cobbler_repo.foo foo
+```

--- a/docs/resources/snippet.md
+++ b/docs/resources/snippet.md
@@ -30,3 +30,11 @@ resource "cobbler_snippet" "my_snippet" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import cobbler_snippet.foo foo
+```

--- a/docs/resources/system.md
+++ b/docs/resources/system.md
@@ -134,3 +134,11 @@ Optional:
 - `static` (Boolean) Whether the interface should be static or DHCP.
 - `static_routes` (List of String) Static routes for the interface.
 - `virt_bridge` (String) The virtual bridge to attach to.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import cobbler_system.foo foo
+```

--- a/docs/resources/template_file.md
+++ b/docs/resources/template_file.md
@@ -30,3 +30,11 @@ resource "cobbler_template_file" "my_template" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import cobbler_template_file.foo foo
+```

--- a/examples/resources/cobbler_distro/import.sh
+++ b/examples/resources/cobbler_distro/import.sh
@@ -1,0 +1,1 @@
+terraform import cobbler_distro.foo foo

--- a/examples/resources/cobbler_profile/import.sh
+++ b/examples/resources/cobbler_profile/import.sh
@@ -1,0 +1,1 @@
+terraform import cobbler_profile.foo foo

--- a/examples/resources/cobbler_repo/import.sh
+++ b/examples/resources/cobbler_repo/import.sh
@@ -1,0 +1,1 @@
+terraform import cobbler_repo.foo foo

--- a/examples/resources/cobbler_snippet/import.sh
+++ b/examples/resources/cobbler_snippet/import.sh
@@ -1,0 +1,1 @@
+terraform import cobbler_snippet.foo foo

--- a/examples/resources/cobbler_system/import.sh
+++ b/examples/resources/cobbler_system/import.sh
@@ -1,0 +1,1 @@
+terraform import cobbler_system.foo foo

--- a/examples/resources/cobbler_template_file/import.sh
+++ b/examples/resources/cobbler_template_file/import.sh
@@ -1,0 +1,1 @@
+terraform import cobbler_template_file.foo foo


### PR DESCRIPTION
## Linked Items

Fixes #52

## Description

This PR adds support for `terraform import`.

## Behaviour changes

Old: Calling `terraform import` results in a "resource doesn't support ..."

New: Untracked resources can be imported.

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [x] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required
