### PR TITLE
Add remote_boot_kernel and remote_boot_initrd to distro resource

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,4 +40,4 @@ jobs:
         # https://github.com/golangci/golangci-lint-action
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61
+          version: v1.64.5

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 # Visit https://golangci-lint.run/ for usage documentation
 # and information on other useful linters
 issues:
-  max-per-linter: 0
   max-same-issues: 0
 
 linters:

--- a/cobbler/resource_cobbler_distro.go
+++ b/cobbler/resource_cobbler_distro.go
@@ -87,10 +87,22 @@ func resourceDistro() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
+			"remote_boot_initrd": {
+				Description: "URL the bootloader directly retrieves and boots from",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+			},
 			"kernel": {
 				Description: "Absolute path to kernel on filesystem. This must already exist prior to creating the distro.",
 				Type:        schema.TypeString,
 				Required:    true,
+			},
+			"remote_boot_kernel": {
+				Description: "URL the bootloader directly retrieves and boots from",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
 			},
 			"kernel_options": {
 				Description: "Kernel options to use with the kernel.",
@@ -242,6 +254,14 @@ func resourceDistroRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return diag.FromErr(err)
 	}
 	err = d.Set("kernel", distro.Kernel)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set("remote_boot_initrd", distro.RemoteBootInitrd)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	err = d.Set("remote_boot_kernel", distro.RemoteBootKernel)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/docs/resources/distro.md
+++ b/docs/resources/distro.md
@@ -52,6 +52,8 @@ resource "cobbler_distro" "Ubuntu-2004-x86_64" {
 - `os_version` (String) The version of the distro you are creating. This varies with the version of Cobbler you are using. An updated signature list may need to be obtained in order to support a newer version. Example: `focal`.
 - `owners` (List of String) Owners list for authz_ownership.
 - `owners_inherit` (Boolean) Signal that owners should be set to inherit from its parent
+- `remote_boot_initrd` (String) URL the bootloader directly retrieves and boots from
+- `remote_boot_kernel` (String) URL the bootloader directly retrieves and boots from
 - `template_files` (Map of String) File mappings for built-in config management.
 - `template_files_inherit` (Boolean) Signal that template_files should be set to inherit from its parent
 


### PR DESCRIPTION
## Linked Items

Fixes #57

## Description

This adds the following two fields to the `cobbler_distro` resource:

- `remote_boot_kernel`
- `remote_boot_initrd`

## Behaviour changes

Old: The two fields couldn't be set with the help of the provider.

New: The two fields can be managed via the provider.

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required
