### PR TITLE
Distro: Fix object building for remote_boot_* attributes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Checkout
         # https://github.com/actions/checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
       - name: Set up Go
         # https://github.com/actions/setup-go
         uses: actions/setup-go@v5

--- a/cobbler/resource_cobbler_distro.go
+++ b/cobbler/resource_cobbler_distro.go
@@ -382,6 +382,7 @@ func buildDistro(d *schema.ResourceData, meta interface{}) (cobbler.Distro, erro
 		IsInherited: IsOptionInherited(d, "fetchable_files"),
 	}
 	distro.Kernel = d.Get("kernel").(string)
+	distro.RemoteBootKernel = d.Get("remote_boot_kernel").(string)
 	distro.KernelOptions = cobbler.Value[map[string]interface{}]{
 		Data:        kernelOptions,
 		IsInherited: IsOptionInherited(d, "kernel_options"),
@@ -391,6 +392,7 @@ func buildDistro(d *schema.ResourceData, meta interface{}) (cobbler.Distro, erro
 		IsInherited: IsOptionInherited(d, "kernel_options_post"),
 	}
 	distro.Initrd = d.Get("initrd").(string)
+	distro.RemoteBootInitrd = d.Get("remote_boot_initrd").(string)
 	distro.MgmtClasses = cobbler.Value[[]string]{
 		Data:        mgmtClasses,
 		IsInherited: IsOptionInherited(d, "mgmt_classes"),


### PR DESCRIPTION
## Linked Items

Fixes a bug related to `remote_boot_kernel` and `remote_boot_initrd`.

## Description

See linked items

## Behaviour changes

Old: The two attributes are not set

New: The two attributes are set

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
