### PR TITLE
Fix Distro boot_loaders

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,7 +23,7 @@ test: fmtcheck
 .PHONY: testacc
 testacc:
 	@COBBLER_VERSION=v3.3.0 sh -c "'./docker/start.sh' $(COBBLER_SERVER_URL)"
-	TF_LOG=TRACE TF_ACC_LOG=TRACE TF_LOG_PATH_MASK="test-%s.log" TF_ACC=1 TF_ACC_PROVIDER_NAMESPACE=cobbler COBBLER_URL=$(COBBLER_SERVER_URL) COBBLER_USERNAME=cobbler COBBLER_PASSWORD=cobbler go test -v -coverprofile="coverage.out" -covermode="atomic" $(TEST)
+	TF_LOG=TRACE TF_ACC_LOG=TRACE TF_LOG_PATH_MASK="test-%s.log" TF_ACC=1 TF_ACC_PROVIDER_NAMESPACE=cobbler COBBLER_URL=$(COBBLER_SERVER_URL) COBBLER_USERNAME=cobbler COBBLER_PASSWORD=cobbler go test -v -coverprofile="coverage.out" -covermode="atomic" './...'
 
 .PHONY: docs
 docs:

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -4,8 +4,8 @@ services:
     container_name: cobbler-dev
     privileged: true  # Required for Cobbler 3.3.2 and newer
     volumes:
-      - ./cobbler_source:/code
-      - ../extracted_iso_image:/extracted_iso_image
+      - ./cobbler_source:/code:z
+      - ../extracted_iso_image:/extracted_iso_image:z
     ports:
       - 8081:80
     # We chmod the code, otherwise some files are read-only and cannot be cleaned up:

--- a/internal/distro/resource.go
+++ b/internal/distro/resource.go
@@ -12,8 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -115,9 +113,6 @@ func (r *DistroResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						ElementType: types.StringType,
 						Optional:    true,
 						Computed:    true,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Optional: true,
@@ -140,9 +135,6 @@ func (r *DistroResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						ElementType: types.StringType,
 						Optional:    true,
 						Computed:    true,
-						PlanModifiers: []planmodifier.List{
-							listplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Optional: true,
@@ -165,9 +157,6 @@ func (r *DistroResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						ElementType: types.StringType,
 						Optional:    true,
 						Computed:    true,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Optional: true,
@@ -190,9 +179,6 @@ func (r *DistroResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						ElementType: types.StringType,
 						Optional:    true,
 						Computed:    true,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Optional: true,
@@ -215,9 +201,6 @@ func (r *DistroResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						ElementType: types.StringType,
 						Optional:    true,
 						Computed:    true,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Optional: true,
@@ -240,9 +223,6 @@ func (r *DistroResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						ElementType: types.StringType,
 						Optional:    true,
 						Computed:    true,
-						PlanModifiers: []planmodifier.List{
-							listplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Optional: true,
@@ -265,9 +245,6 @@ func (r *DistroResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						ElementType: types.StringType,
 						Optional:    true,
 						Computed:    true,
-						PlanModifiers: []planmodifier.List{
-							listplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Optional: true,

--- a/internal/distro/resource_test.go
+++ b/internal/distro/resource_test.go
@@ -108,6 +108,75 @@ resource "cobbler_distro" "foo" {
 }
 `
 
+// TestAccDistroResource_bootLoadersExplicit reproduces GH issue #20:
+// setting an explicit boot_loaders value (not inherited) should not error.
+func TestAccDistroResource_bootLoadersExplicit(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDistroResourceBootLoadersExplicit,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cobbler_distro.foo", "name", "foo-resource-distro-boot-loaders"),
+					resource.TestCheckResourceAttr("cobbler_distro.foo", "boot_loaders.inherited", "false"),
+					resource.TestCheckResourceAttr("cobbler_distro.foo", "boot_loaders.value.0", "grub"),
+				),
+			},
+			{
+				// Switch to inherited and back to explicit to catch update-path regressions.
+				Config: testAccDistroResourceBootLoadersInherited,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cobbler_distro.foo", "boot_loaders.inherited", "true"),
+				),
+			},
+			{
+				Config: testAccDistroResourceBootLoadersExplicit,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cobbler_distro.foo", "boot_loaders.inherited", "false"),
+					resource.TestCheckResourceAttr("cobbler_distro.foo", "boot_loaders.value.0", "grub"),
+				),
+			},
+			{
+				ResourceName:                         "cobbler_distro.foo",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateId:                        "foo-resource-distro-boot-loaders",
+				ImportStateVerifyIdentifierAttribute: "name",
+			},
+		},
+	})
+}
+
+const testAccDistroResourceBootLoadersExplicit = `
+resource "cobbler_distro" "foo" {
+  name       = "foo-resource-distro-boot-loaders"
+  breed      = "ubuntu"
+  os_version = "focal"
+  arch       = "x86_64"
+  kernel     = "/srv/www/cobbler/distro_mirror/Ubuntu-20.04/install/vmlinuz"
+  initrd     = "/srv/www/cobbler/distro_mirror/Ubuntu-20.04/install/initrd.gz"
+  boot_loaders = {
+    inherited = false
+    value     = ["grub"]
+  }
+}
+`
+
+const testAccDistroResourceBootLoadersInherited = `
+resource "cobbler_distro" "foo" {
+  name       = "foo-resource-distro-boot-loaders"
+  breed      = "ubuntu"
+  os_version = "focal"
+  arch       = "x86_64"
+  kernel     = "/srv/www/cobbler/distro_mirror/Ubuntu-20.04/install/vmlinuz"
+  initrd     = "/srv/www/cobbler/distro_mirror/Ubuntu-20.04/install/initrd.gz"
+  boot_loaders = {
+    inherited = true
+  }
+}
+`
+
 const testAccDistroResourceChange1 = `
 resource "cobbler_distro" "foo" {
   name       = "foo-resource-distro-change"

--- a/internal/image/resource.go
+++ b/internal/image/resource.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -219,9 +218,6 @@ func (r *ImageResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 						ElementType: types.StringType,
 						Optional:    true,
 						Computed:    true,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Optional: true,
@@ -244,9 +240,6 @@ func (r *ImageResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 						ElementType: types.StringType,
 						Optional:    true,
 						Computed:    true,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Optional: true,
@@ -269,9 +262,6 @@ func (r *ImageResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 						ElementType: types.StringType,
 						Optional:    true,
 						Computed:    true,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Optional: true,
@@ -294,9 +284,6 @@ func (r *ImageResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 						ElementType: types.StringType,
 						Optional:    true,
 						Computed:    true,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Optional: true,
@@ -319,9 +306,6 @@ func (r *ImageResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 						ElementType: types.StringType,
 						Optional:    true,
 						Computed:    true,
-						PlanModifiers: []planmodifier.List{
-							listplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Optional: true,
@@ -344,9 +328,6 @@ func (r *ImageResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 						ElementType: types.StringType,
 						Optional:    true,
 						Computed:    true,
-						PlanModifiers: []planmodifier.List{
-							listplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Optional: true,

--- a/internal/menu/resource.go
+++ b/internal/menu/resource.go
@@ -144,9 +144,6 @@ func inheritedMapAttrs() map[string]schema.Attribute {
 			ElementType: types.StringType,
 			Optional:    true,
 			Computed:    true,
-			PlanModifiers: []planmodifier.Map{
-				mapplanmodifier.UseStateForUnknown(),
-			},
 		},
 		"inherited": schema.BoolAttribute{
 			Optional: true,

--- a/internal/profile/resource.go
+++ b/internal/profile/resource.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -179,9 +178,6 @@ func (r *ProfileResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Description: "If true, inherited from parent.",
@@ -206,9 +202,6 @@ func (r *ProfileResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Description: "If true, inherited from parent.",
@@ -285,9 +278,6 @@ func (r *ProfileResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Description: "If true, inherited from parent.",
@@ -312,9 +302,6 @@ func (r *ProfileResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Description: "If true, inherited from parent.",
@@ -339,9 +326,6 @@ func (r *ProfileResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Description: "If true, inherited from parent.",
@@ -366,9 +350,6 @@ func (r *ProfileResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
-						PlanModifiers: []planmodifier.List{
-							listplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Description: "If true, inherited from parent.",
@@ -393,9 +374,6 @@ func (r *ProfileResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Description: "If true, inherited from parent.",
@@ -420,9 +398,6 @@ func (r *ProfileResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
-						PlanModifiers: []planmodifier.List{
-							listplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Description: "If true, inherited from parent.",
@@ -447,9 +422,6 @@ func (r *ProfileResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
-						PlanModifiers: []planmodifier.List{
-							listplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Description: "If true, inherited from parent.",
@@ -474,9 +446,6 @@ func (r *ProfileResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
-						PlanModifiers: []planmodifier.List{
-							listplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Description: "If true, inherited from parent.",
@@ -501,9 +470,6 @@ func (r *ProfileResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Description: "If true, inherited from parent.",

--- a/internal/repo/resource.go
+++ b/internal/repo/resource.go
@@ -163,9 +163,6 @@ func (r *RepoResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 						ElementType: types.StringType,
 						Optional:    true,
 						Computed:    true,
-						PlanModifiers: []planmodifier.List{
-							listplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Optional: true,

--- a/internal/system/resource.go
+++ b/internal/system/resource.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -246,9 +245,6 @@ func (r *SystemResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Description: "If true, inherited from parent.",
@@ -273,9 +269,6 @@ func (r *SystemResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Description: "If true, inherited from parent.",
@@ -300,9 +293,6 @@ func (r *SystemResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
-						PlanModifiers: []planmodifier.List{
-							listplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Description: "If true, inherited from parent.",
@@ -353,9 +343,6 @@ func (r *SystemResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Description: "If true, inherited from parent.",
@@ -380,9 +367,6 @@ func (r *SystemResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Description: "If true, inherited from parent.",
@@ -407,9 +391,6 @@ func (r *SystemResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Description: "If true, inherited from parent.",
@@ -434,9 +415,6 @@ func (r *SystemResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
-						PlanModifiers: []planmodifier.List{
-							listplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Description: "If true, inherited from parent.",
@@ -461,9 +439,6 @@ func (r *SystemResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Description: "If true, inherited from parent.",
@@ -488,9 +463,6 @@ func (r *SystemResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
-						PlanModifiers: []planmodifier.List{
-							listplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Description: "If true, inherited from parent.",
@@ -515,9 +487,6 @@ func (r *SystemResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    true,
 						ElementType: types.StringType,
-						PlanModifiers: []planmodifier.Map{
-							mapplanmodifier.UseStateForUnknown(),
-						},
 					},
 					"inherited": schema.BoolAttribute{
 						Description: "If true, inherited from parent.",


### PR DESCRIPTION
## Linked Items

Fixes #20 

## Description

This PR fixes an issue where inherited attributes could not be transitioned from `inherit=true` to a concrete value. This was due to the usage of the planmodifier `UseStateForUnknown()`.

## Behaviour changes

Old: Inherited values cannot be switched to concrete ones.

New: Inherited values can be switched to concrete ones.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [x] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required
