### PR TITLE
feat!: require a uid for get/remove item RPC calls

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
         # https://github.com/golangci/golangci-lint-action
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.9.0
+          version: v2.13.1
   commit-lint:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -58,7 +58,7 @@ jobs:
           - terraform
           - opentofu
         cobbler_version:
-          - v4.0.0b1
+          - v4.0.0b5
       fail-fast: false
     steps:
       - name: Check out code into the Go module directory
@@ -112,7 +112,7 @@ jobs:
             *.iso
           key: ${{ steps.cache-iso-restore.outputs.cache-primary-key }}
       - name: Upload coverage report to GH artifacts
-        if: matrix.cobbler_version == 'v4.0.0b1' && matrix.tool == 'terraform'
+        if: matrix.cobbler_version == 'v4.0.0b5' && matrix.tool == 'terraform'
         # https://github.com/actions/upload-artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -6,7 +6,7 @@ if [ -z "$1" ]
     echo "No cobbler server url supplied"
 fi
 
-cobbler_image_tag=v4.0.0b1
+cobbler_image_tag=v4.0.0b5
 iso_url=https://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04.1-legacy-server-amd64.iso
 iso_os=ubuntu
 valid_iso_checksum=00a9d46306fbe9beb3581853a289490bc231c51f
@@ -59,6 +59,7 @@ python3 docker/import.py
 docker compose -f docker/compose.yml exec cobbler touch \
   /var/lib/cobbler/templates/foo-resource-template-basic.j2 \
   /var/lib/cobbler/templates/foo-resource-template-change.j2 \
-  /var/lib/cobbler/templates/foo-ds-template.j2
+  /var/lib/cobbler/templates/foo-ds-template.j2 \
+  /var/lib/cobbler/templates/foo-resource-template-import-not-found.j2
 
 docker compose -f docker/compose.yml logs

--- a/docs/data-sources/distro_group.md
+++ b/docs/data-sources/distro_group.md
@@ -23,3 +23,4 @@ Use this data source to look up a Cobbler distro group (4.0.0+).
 
 - `comment` (String) Free form text description.
 - `items` (List of String) Distro names in the group.
+- `uid` (String) Server-assigned UID for this distro group.

--- a/docs/data-sources/distro_group.md
+++ b/docs/data-sources/distro_group.md
@@ -22,5 +22,5 @@ Use this data source to look up a Cobbler distro group (4.0.0+).
 ### Read-Only
 
 - `comment` (String) Free form text description.
-- `items` (List of String) Distro names in the group.
+- `items` (List of String) Distro UIDs in the group.
 - `uid` (String) Server-assigned UID for this distro group.

--- a/docs/data-sources/network_interface.md
+++ b/docs/data-sources/network_interface.md
@@ -38,6 +38,7 @@ Use this data source to look up a Cobbler network interface (Cobbler 4.0.0+).
 - `static` (Boolean) Static (true) or DHCP (false).
 - `system` (String) The UID of the parent system.
 - `system_name` (String) The name of the parent system.
+- `uid` (String) Server-assigned UID for this network interface.
 - `virt_bridge` (Attributes) The virtual bridge to attach to (inheritable). (see [below for nested schema](#nestedatt--virt_bridge))
 
 <a id="nestedatt--dns"></a>

--- a/docs/data-sources/profile_group.md
+++ b/docs/data-sources/profile_group.md
@@ -23,3 +23,4 @@ Use this data source to look up a Cobbler profile group (4.0.0+).
 
 - `comment` (String) Free form text description.
 - `items` (List of String) Distro names in the group.
+- `uid` (String) Server-assigned UID for this profile group.

--- a/docs/data-sources/profile_group.md
+++ b/docs/data-sources/profile_group.md
@@ -22,5 +22,5 @@ Use this data source to look up a Cobbler profile group (4.0.0+).
 ### Read-Only
 
 - `comment` (String) Free form text description.
-- `items` (List of String) Distro names in the group.
+- `items` (List of String) Profile UIDs in the group.
 - `uid` (String) Server-assigned UID for this profile group.

--- a/docs/data-sources/repo.md
+++ b/docs/data-sources/repo.md
@@ -34,6 +34,7 @@ Use this data source to get the details of a Cobbler repo.
 - `owners` (Attributes) List of Owners for authz_ownership. (see [below for nested schema](#nestedatt--owners))
 - `proxy` (Attributes) Proxy to use for downloading the repo. (see [below for nested schema](#nestedatt--proxy))
 - `rpm_list` (List of String) List of specific RPMs to mirror.
+- `uid` (String) Server-assigned UID for this repo.
 
 <a id="nestedatt--createrepo_flags"></a>
 ### Nested Schema for `createrepo_flags`

--- a/docs/data-sources/system_group.md
+++ b/docs/data-sources/system_group.md
@@ -23,3 +23,4 @@ Use this data source to look up a Cobbler system group (4.0.0+).
 
 - `comment` (String) Free form text description.
 - `items` (List of String) Distro names in the group.
+- `uid` (String) Server-assigned UID for this system group.

--- a/docs/data-sources/system_group.md
+++ b/docs/data-sources/system_group.md
@@ -22,5 +22,5 @@ Use this data source to look up a Cobbler system group (4.0.0+).
 ### Read-Only
 
 - `comment` (String) Free form text description.
-- `items` (List of String) Distro names in the group.
+- `items` (List of String) System UIDs in the group.
 - `uid` (String) Server-assigned UID for this system group.

--- a/docs/data-sources/template.md
+++ b/docs/data-sources/template.md
@@ -26,6 +26,7 @@ Use this data source to look up a Cobbler template (4.0.0+).
 - `content` (String) The template body.
 - `tags` (List of String) Tags.
 - `template_type` (String) The template engine.
+- `uid` (String) Server-assigned UID for this template.
 - `uri` (Attributes) Where the template's content lives. (see [below for nested schema](#nestedatt--uri))
 
 <a id="nestedatt--uri"></a>

--- a/docs/resources/distro_group.md
+++ b/docs/resources/distro_group.md
@@ -22,7 +22,7 @@ description: |-
 ### Optional
 
 - `comment` (String) Free form text description.
-- `items` (List of String) Names of the distros belonging to this group.
+- `items` (List of String) UIDs of the distros belonging to this group.
 
 ### Read-Only
 

--- a/docs/resources/distro_group.md
+++ b/docs/resources/distro_group.md
@@ -23,3 +23,7 @@ description: |-
 
 - `comment` (String) Free form text description.
 - `items` (List of String) Names of the distros belonging to this group.
+
+### Read-Only
+
+- `uid` (String) Server-assigned UID for this distro group.

--- a/docs/resources/network_interface.md
+++ b/docs/resources/network_interface.md
@@ -42,6 +42,7 @@ description: |-
 ### Read-Only
 
 - `system_name` (String) The name of the parent system (computed echo from the server).
+- `uid` (String) Server-assigned UID for this network interface.
 
 <a id="nestedatt--dns"></a>
 ### Nested Schema for `dns`

--- a/docs/resources/profile_group.md
+++ b/docs/resources/profile_group.md
@@ -22,7 +22,7 @@ description: |-
 ### Optional
 
 - `comment` (String) Free form text description.
-- `items` (List of String) Names of the distros belonging to this group.
+- `items` (List of String) UIDs of the profiles belonging to this group.
 
 ### Read-Only
 

--- a/docs/resources/profile_group.md
+++ b/docs/resources/profile_group.md
@@ -23,3 +23,7 @@ description: |-
 
 - `comment` (String) Free form text description.
 - `items` (List of String) Names of the distros belonging to this group.
+
+### Read-Only
+
+- `uid` (String) Server-assigned UID for this profile group.

--- a/docs/resources/repo.md
+++ b/docs/resources/repo.md
@@ -46,6 +46,10 @@ resource "cobbler_repo" "my_repo" {
 - `proxy` (Attributes) Proxy to use for downloading the repo. (see [below for nested schema](#nestedatt--proxy))
 - `rpm_list` (List of String) List of specific RPMs to mirror.
 
+### Read-Only
+
+- `uid` (String) Server-assigned UID for this repo.
+
 <a id="nestedatt--createrepo_flags"></a>
 ### Nested Schema for `createrepo_flags`
 

--- a/docs/resources/system_group.md
+++ b/docs/resources/system_group.md
@@ -22,7 +22,7 @@ description: |-
 ### Optional
 
 - `comment` (String) Free form text description.
-- `items` (List of String) Names of the distros belonging to this group.
+- `items` (List of String) UIDs of the systems belonging to this group.
 
 ### Read-Only
 

--- a/docs/resources/system_group.md
+++ b/docs/resources/system_group.md
@@ -23,3 +23,7 @@ description: |-
 
 - `comment` (String) Free form text description.
 - `items` (List of String) Names of the distros belonging to this group.
+
+### Read-Only
+
+- `uid` (String) Server-assigned UID for this system group.

--- a/docs/resources/template.md
+++ b/docs/resources/template.md
@@ -30,6 +30,7 @@ description: |-
 ### Read-Only
 
 - `built_in` (Boolean) Whether the template is built into Cobbler (read-only).
+- `uid` (String) Server-assigned UID for this template.
 
 <a id="nestedatt--uri"></a>
 ### Nested Schema for `uri`

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cobbler/terraform-provider-cobbler
 go 1.25.8
 
 require (
-	github.com/cobbler/cobblerclient v1.0.0-rc3
+	github.com/cobbler/cobblerclient v1.0.0-rc5
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/cobbler/cobblerclient v1.0.0-rc3 h1:2ZSThkEUx/Y0CJjZm+LDlZHQ5wVGE053kdsppAdUtlo=
-github.com/cobbler/cobblerclient v1.0.0-rc3/go.mod h1:BoS4GMBvwnypRHcOMedyipm+0Pu7IP5pSX6A/DqU6mo=
+github.com/cobbler/cobblerclient v1.0.0-rc5 h1:CBA8efMyegOKCaYintZg/ps3vw7pZCeOKCdELtvvbLs=
+github.com/cobbler/cobblerclient v1.0.0-rc5/go.mod h1:BoS4GMBvwnypRHcOMedyipm+0Pu7IP5pSX6A/DqU6mo=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=
 github.com/cyphar/filepath-securejoin v0.4.1/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/client/find.go
+++ b/internal/client/find.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// ResolveUnique extracts the uid from the single element of matches (as returned by one of
+// the cobblerclient Find<Type> calls keyed on {"name": name}), adding a clear diagnostic
+// error if there isn't exactly one match.
+//
+// Cobbler item names are not guaranteed unique across the whole server for every item type
+// (e.g. NetworkInterface names are only unique per-system), so a name-based lookup can
+// legitimately return zero or more than one result; callers must not silently pick one.
+func ResolveUnique[T any](diags *diag.Diagnostics, typeName, name string, matches []T, uidOf func(T) string) (string, bool) {
+	switch len(matches) {
+	case 0:
+		diags.AddError(
+			fmt.Sprintf("Cobbler %s not found", typeName),
+			fmt.Sprintf("No %s was found with name %q.", typeName, name),
+		)
+		return "", false
+	case 1:
+		return uidOf(matches[0]), true
+	default:
+		diags.AddError(
+			fmt.Sprintf("Ambiguous Cobbler %s name", typeName),
+			fmt.Sprintf("Found %d %s items with name %q; expected exactly one. Cobbler item names are not guaranteed to be globally unique for every item type.", len(matches), typeName, name),
+		)
+		return "", false
+	}
+}

--- a/internal/client/find_test.go
+++ b/internal/client/find_test.go
@@ -1,0 +1,159 @@
+package client_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cobbler/terraform-provider-cobbler/internal/client"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// fakeItem stands in for the cobblerclient item types (e.g. *cobbler.Distro) that
+// ResolveUnique is used with; only the uid extracted via uidOf matters to the helper.
+type fakeItem struct {
+	Uid string
+}
+
+func uidOfFakeItem(i fakeItem) string {
+	return i.Uid
+}
+
+func TestResolveUnique_singleMatch(t *testing.T) {
+	var diags diag.Diagnostics
+	matches := []fakeItem{{Uid: "abc123"}}
+
+	uid, ok := client.ResolveUnique(&diags, "Distro", "d1", matches, uidOfFakeItem)
+
+	if !ok {
+		t.Fatal("expected ok to be true")
+	}
+	if uid != "abc123" {
+		t.Errorf("expected uid %q, got %q", "abc123", uid)
+	}
+	if diags.HasError() {
+		t.Fatalf("expected no diagnostics, got %v", diags)
+	}
+}
+
+func TestResolveUnique_zeroMatches(t *testing.T) {
+	var diags diag.Diagnostics
+	matches := []fakeItem{}
+
+	uid, ok := client.ResolveUnique(&diags, "Distro", "d1", matches, uidOfFakeItem)
+
+	if ok {
+		t.Fatal("expected ok to be false")
+	}
+	if uid != "" {
+		t.Errorf("expected empty uid, got %q", uid)
+	}
+	if !diags.HasError() {
+		t.Fatal("expected diagnostics to have an error")
+	}
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", len(diags))
+	}
+	wantSummary := "Cobbler Distro not found"
+	if diags[0].Summary() != wantSummary {
+		t.Errorf("expected summary %q, got %q", wantSummary, diags[0].Summary())
+	}
+	if !strings.Contains(diags[0].Detail(), "d1") {
+		t.Errorf("expected detail to mention name %q, got %q", "d1", diags[0].Detail())
+	}
+	if !strings.Contains(diags[0].Detail(), "Distro") {
+		t.Errorf("expected detail to mention type %q, got %q", "Distro", diags[0].Detail())
+	}
+}
+
+func TestResolveUnique_multipleMatches(t *testing.T) {
+	var diags diag.Diagnostics
+	matches := []fakeItem{{Uid: "abc123"}, {Uid: "def456"}, {Uid: "ghi789"}}
+
+	uid, ok := client.ResolveUnique(&diags, "NetworkInterface", "eth0", matches, uidOfFakeItem)
+
+	if ok {
+		t.Fatal("expected ok to be false")
+	}
+	if uid != "" {
+		t.Errorf("expected empty uid, got %q", uid)
+	}
+	if !diags.HasError() {
+		t.Fatal("expected diagnostics to have an error")
+	}
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", len(diags))
+	}
+	wantSummary := "Ambiguous Cobbler NetworkInterface name"
+	if diags[0].Summary() != wantSummary {
+		t.Errorf("expected summary %q, got %q", wantSummary, diags[0].Summary())
+	}
+	detail := diags[0].Detail()
+	if !strings.Contains(detail, "3") {
+		t.Errorf("expected detail to mention match count 3, got %q", detail)
+	}
+	if !strings.Contains(detail, "NetworkInterface") {
+		t.Errorf("expected detail to mention type %q, got %q", "NetworkInterface", detail)
+	}
+	if !strings.Contains(detail, "eth0") {
+		t.Errorf("expected detail to mention name %q, got %q", "eth0", detail)
+	}
+}
+
+func TestResolveUnique_emptyTypeNameAndName(t *testing.T) {
+	var diags diag.Diagnostics
+	matches := []fakeItem{}
+
+	uid, ok := client.ResolveUnique(&diags, "", "", matches, uidOfFakeItem)
+
+	if ok {
+		t.Fatal("expected ok to be false")
+	}
+	if uid != "" {
+		t.Errorf("expected empty uid, got %q", uid)
+	}
+	if !diags.HasError() {
+		t.Fatal("expected diagnostics to have an error")
+	}
+	wantSummary := "Cobbler  not found"
+	if diags[0].Summary() != wantSummary {
+		t.Errorf("expected summary %q, got %q", wantSummary, diags[0].Summary())
+	}
+	wantDetail := `No  was found with name "".`
+	if diags[0].Detail() != wantDetail {
+		t.Errorf("expected detail %q, got %q", wantDetail, diags[0].Detail())
+	}
+}
+
+func TestResolveUnique_uidOfCalledOnlyOnSingleMatch(t *testing.T) {
+	// uidOf must not be invoked when there isn't exactly one match, since callers may
+	// rely on it only being safe to dereference fields on an actual match.
+	calls := 0
+	uidOf := func(i fakeItem) string {
+		calls++
+		return i.Uid
+	}
+
+	var diags diag.Diagnostics
+	if _, ok := client.ResolveUnique(&diags, "Distro", "d1", []fakeItem{}, uidOf); ok {
+		t.Fatal("expected ok to be false for zero matches")
+	}
+	if calls != 0 {
+		t.Errorf("expected uidOf not to be called for zero matches, called %d times", calls)
+	}
+
+	diags = nil
+	if _, ok := client.ResolveUnique(&diags, "Distro", "d1", []fakeItem{{Uid: "a"}, {Uid: "b"}}, uidOf); ok {
+		t.Fatal("expected ok to be false for multiple matches")
+	}
+	if calls != 0 {
+		t.Errorf("expected uidOf not to be called for multiple matches, called %d times", calls)
+	}
+
+	diags = nil
+	if _, ok := client.ResolveUnique(&diags, "Distro", "d1", []fakeItem{{Uid: "a"}}, uidOf); !ok {
+		t.Fatal("expected ok to be true for a single match")
+	}
+	if calls != 1 {
+		t.Errorf("expected uidOf to be called exactly once for a single match, called %d times", calls)
+	}
+}

--- a/internal/distro/data_source.go
+++ b/internal/distro/data_source.go
@@ -155,7 +155,17 @@ func (d *DistroDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	distroPtr, err := d.client.GetDistro(data.Name.ValueString(), false, false)
+	matches, err := d.client.FindDistro(map[string]interface{}{"name": data.Name.ValueString()}, false)
+	if err != nil {
+		resp.Diagnostics.AddError("Error resolving Cobbler Distro uid", err.Error())
+		return
+	}
+	uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "Distro", data.Name.ValueString(), matches, func(d *cobbler.Distro) string { return d.Uid })
+	if !ok {
+		return
+	}
+
+	distroPtr, err := d.client.GetDistro(uid, false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler Distro", err.Error())
 		return

--- a/internal/distro/data_source_test.go
+++ b/internal/distro/data_source_test.go
@@ -1,6 +1,7 @@
 package distro_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/cobbler/terraform-provider-cobbler/internal/acctest"
@@ -23,6 +24,28 @@ func TestAccDistroDataSource_basic(t *testing.T) {
 		},
 	})
 }
+
+// TestAccDistroDataSource_notFound exercises the zero-match branch of the data source's
+// name-to-uid resolution (FindDistro + client.ResolveUnique): looking up a name that doesn't
+// exist on the server must surface a clear "not found" diagnostic instead of a raw client error.
+func TestAccDistroDataSource_notFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDistroDataSourceNotFound,
+				ExpectError: regexp.MustCompile(`Cobbler Distro not found`),
+			},
+		},
+	})
+}
+
+const testAccDistroDataSourceNotFound = `
+data "cobbler_distro" "notfound" {
+  name = "does-not-exist-distro-data-source"
+}
+`
 
 const testAccDistroDataSourceBasic = `
 resource "cobbler_distro" "foo" {

--- a/internal/distro/resource.go
+++ b/internal/distro/resource.go
@@ -262,7 +262,20 @@ func (r *DistroResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	distro, err := r.client.GetDistro(data.Name.ValueString(), false, false)
+	if data.UID.IsNull() || data.UID.IsUnknown() || data.UID.ValueString() == "" {
+		matches, err := r.client.FindDistro(map[string]interface{}{"name": data.Name.ValueString()}, false)
+		if err != nil {
+			resp.Diagnostics.AddError("Error resolving Cobbler Distro uid", err.Error())
+			return
+		}
+		uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "Distro", data.Name.ValueString(), matches, func(d *cobbler.Distro) string { return d.Uid })
+		if !ok {
+			return
+		}
+		data.UID = types.StringValue(uid)
+	}
+
+	distro, err := r.client.GetDistro(data.UID.ValueString(), false, false)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			resp.State.RemoveResource(ctx)
@@ -299,7 +312,7 @@ func (r *DistroResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	updatedDistro, err := r.client.GetDistro(data.Name.ValueString(), false, false)
+	updatedDistro, err := r.client.GetDistro(data.UID.ValueString(), false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler Distro after update", err.Error())
 		return
@@ -322,7 +335,7 @@ func (r *DistroResource) Delete(ctx context.Context, req resource.DeleteRequest,
 
 	tflog.Debug(ctx, "Cobbler Distro: Delete", map[string]interface{}{"name": data.Name.ValueString()})
 
-	if err := r.client.DeleteDistro(data.Name.ValueString()); err != nil {
+	if err := r.client.DeleteDistro(data.UID.ValueString()); err != nil {
 		resp.Diagnostics.AddError("Error deleting Cobbler Distro", err.Error())
 	}
 }

--- a/internal/distro/resource_test.go
+++ b/internal/distro/resource_test.go
@@ -1,6 +1,7 @@
 package distro_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/cobbler/terraform-provider-cobbler/internal/acctest"
@@ -86,6 +87,42 @@ func TestAccDistroResource_change(t *testing.T) {
 const testAccDistroResourceBasic = `
 resource "cobbler_distro" "foo" {
   name       = "foo-resource-distro-basic"
+  breed      = "ubuntu"
+  os_version = "focal"
+  arch       = "x86_64"
+  kernel     = "/srv/www/cobbler/distro_mirror/Ubuntu-20.04/install/vmlinuz"
+  initrd     = "/srv/www/cobbler/distro_mirror/Ubuntu-20.04/install/initrd.gz"
+}
+`
+
+// TestAccDistroResource_importNotFound exercises the zero-match branch of the resource's
+// post-import name-to-uid resolution fallback (used because ImportStatePassthroughID only
+// populates "name", leaving "uid" null): importing an ID that doesn't match any Distro on the
+// server must surface a clear "not found" diagnostic instead of a raw client error.
+func TestAccDistroResource_importNotFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDistroResourceImportNotFound,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cobbler_distro.notfound", "name", "foo-resource-distro-import-not-found"),
+				),
+			},
+			{
+				ResourceName:  "cobbler_distro.notfound",
+				ImportState:   true,
+				ImportStateId: "does-not-exist-distro-resource",
+				ExpectError:   regexp.MustCompile(`Cobbler Distro not found`),
+			},
+		},
+	})
+}
+
+const testAccDistroResourceImportNotFound = `
+resource "cobbler_distro" "notfound" {
+  name       = "foo-resource-distro-import-not-found"
   breed      = "ubuntu"
   os_version = "focal"
   arch       = "x86_64"

--- a/internal/distro_group/data_source.go
+++ b/internal/distro_group/data_source.go
@@ -31,7 +31,7 @@ func (d *DistroGroupDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 			"name":    dsschema.StringAttribute{Description: "Name of the group.", Required: true},
 			"uid":     dsschema.StringAttribute{Description: "Server-assigned UID for this distro group.", Computed: true},
 			"comment": dsschema.StringAttribute{Description: "Free form text description.", Computed: true},
-			"items":   dsschema.ListAttribute{Description: "Distro names in the group.", Computed: true, ElementType: types.StringType},
+			"items":   dsschema.ListAttribute{Description: "Distro UIDs in the group.", Computed: true, ElementType: types.StringType},
 		},
 	}
 }

--- a/internal/distro_group/data_source.go
+++ b/internal/distro_group/data_source.go
@@ -29,6 +29,7 @@ func (d *DistroGroupDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 		Description: "Use this data source to look up a Cobbler distro group (4.0.0+).",
 		Attributes: map[string]dsschema.Attribute{
 			"name":    dsschema.StringAttribute{Description: "Name of the group.", Required: true},
+			"uid":     dsschema.StringAttribute{Description: "Server-assigned UID for this distro group.", Computed: true},
 			"comment": dsschema.StringAttribute{Description: "Free form text description.", Computed: true},
 			"items":   dsschema.ListAttribute{Description: "Distro names in the group.", Computed: true, ElementType: types.StringType},
 		},
@@ -55,7 +56,17 @@ func (d *DistroGroupDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	g, err := d.client.GetDistroGroup(data.Name.ValueString(), false, false)
+	matches, err := d.client.FindDistroGroup(map[string]interface{}{"name": data.Name.ValueString()}, false)
+	if err != nil {
+		resp.Diagnostics.AddError("Error resolving Cobbler DistroGroup uid", err.Error())
+		return
+	}
+	uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "DistroGroup", data.Name.ValueString(), matches, func(dg *cobbler.DistroGroup) string { return dg.Uid })
+	if !ok {
+		return
+	}
+
+	g, err := d.client.GetDistroGroup(uid, false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler DistroGroup", err.Error())
 		return

--- a/internal/distro_group/data_source_model.go
+++ b/internal/distro_group/data_source_model.go
@@ -4,6 +4,7 @@ import "github.com/hashicorp/terraform-plugin-framework/types"
 
 type distroGroupDataSourceModel struct {
 	Name    types.String `tfsdk:"name"`
+	UID     types.String `tfsdk:"uid"`
 	Comment types.String `tfsdk:"comment"`
 	Items   types.List   `tfsdk:"items"`
 }

--- a/internal/distro_group/data_source_test.go
+++ b/internal/distro_group/data_source_test.go
@@ -1,6 +1,7 @@
 package distro_group_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/cobbler/terraform-provider-cobbler/internal/acctest"
@@ -24,6 +25,31 @@ func TestAccDistroGroupDataSource_basic(t *testing.T) {
 		},
 	})
 }
+
+// TestAccDistroGroupDataSource_notFound exercises the zero-match branch of the data source's
+// name-to-uid resolution: looking up a name that doesn't exist on the server must surface a
+// clear "not found" diagnostic instead of a raw client error.
+func TestAccDistroGroupDataSource_notFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.SkipIfCobblerVersionLessThan(t, 4, 0, 0)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDistroGroupDataSourceNotFound,
+				ExpectError: regexp.MustCompile(`Cobbler DistroGroup not found`),
+			},
+		},
+	})
+}
+
+const testAccDistroGroupDataSourceNotFound = `
+data "cobbler_distro_group" "notfound" {
+  name = "does-not-exist-distro-group-data-source"
+}
+`
 
 const testAccDistroGroupDataSourceBasic = `
 resource "cobbler_distro_group" "foo" {

--- a/internal/distro_group/resource.go
+++ b/internal/distro_group/resource.go
@@ -59,7 +59,7 @@ func (r *DistroGroupResource) Schema(_ context.Context, _ resource.SchemaRequest
 				},
 			},
 			"items": schema.ListAttribute{
-				Description: "Names of the distros belonging to this group.",
+				Description: "UIDs of the distros belonging to this group.",
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,

--- a/internal/distro_group/resource.go
+++ b/internal/distro_group/resource.go
@@ -43,6 +43,13 @@ func (r *DistroGroupResource) Schema(_ context.Context, _ resource.SchemaRequest
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"uid": schema.StringAttribute{
+				Description: "Server-assigned UID for this distro group.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"comment": schema.StringAttribute{
 				Description: "Free form text description.",
 				Optional:    true,
@@ -95,6 +102,7 @@ func modelToGroup(ctx context.Context, data distroGroupResourceModel, diags *dia
 
 func groupToModel(ctx context.Context, g cobbler.DistroGroup, data *distroGroupResourceModel, diags *diag.Diagnostics) {
 	data.Name = types.StringValue(g.Name)
+	data.UID = types.StringValue(g.Uid)
 	data.Comment = types.StringValue(g.Comment)
 
 	items := g.Members
@@ -108,6 +116,7 @@ func groupToModel(ctx context.Context, g cobbler.DistroGroup, data *distroGroupR
 
 func groupToDataSourceModel(ctx context.Context, g cobbler.DistroGroup, data *distroGroupDataSourceModel, diags *diag.Diagnostics) {
 	data.Name = types.StringValue(g.Name)
+	data.UID = types.StringValue(g.Uid)
 	data.Comment = types.StringValue(g.Comment)
 
 	items := g.Members
@@ -153,7 +162,20 @@ func (r *DistroGroupResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	g, err := r.client.GetDistroGroup(data.Name.ValueString(), false, false)
+	if data.UID.IsNull() || data.UID.IsUnknown() || data.UID.ValueString() == "" {
+		matches, err := r.client.FindDistroGroup(map[string]interface{}{"name": data.Name.ValueString()}, false)
+		if err != nil {
+			resp.Diagnostics.AddError("Error resolving Cobbler DistroGroup uid", err.Error())
+			return
+		}
+		uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "DistroGroup", data.Name.ValueString(), matches, func(dg *cobbler.DistroGroup) string { return dg.Uid })
+		if !ok {
+			return
+		}
+		data.UID = types.StringValue(uid)
+	}
+
+	g, err := r.client.GetDistroGroup(data.UID.ValueString(), false, false)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			resp.State.RemoveResource(ctx)
@@ -189,7 +211,7 @@ func (r *DistroGroupResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	updated, err := r.client.GetDistroGroup(g.Name, false, false)
+	updated, err := r.client.GetDistroGroup(data.UID.ValueString(), false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler DistroGroup after update", err.Error())
 		return
@@ -211,7 +233,7 @@ func (r *DistroGroupResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	tflog.Debug(ctx, "Cobbler DistroGroup: Delete", map[string]interface{}{"name": data.Name.ValueString()})
 
-	if err := r.client.DeleteDistroGroup(data.Name.ValueString()); err != nil {
+	if err := r.client.DeleteDistroGroup(data.UID.ValueString()); err != nil {
 		resp.Diagnostics.AddError("Error deleting Cobbler DistroGroup", err.Error())
 	}
 }

--- a/internal/distro_group/resource_model.go
+++ b/internal/distro_group/resource_model.go
@@ -4,6 +4,7 @@ import "github.com/hashicorp/terraform-plugin-framework/types"
 
 type distroGroupResourceModel struct {
 	Name    types.String `tfsdk:"name"`
+	UID     types.String `tfsdk:"uid"`
 	Comment types.String `tfsdk:"comment"`
 	Items   types.List   `tfsdk:"items"`
 }

--- a/internal/distro_group/resource_test.go
+++ b/internal/distro_group/resource_test.go
@@ -39,3 +39,94 @@ resource "cobbler_distro_group" "foo" {
   comment = "A distro group"
 }
 `
+
+// TestAccDistroGroupResource_change exercises the Update lifecycle: changing the
+// comment and adding/removing members from the group's "items" list.
+func TestAccDistroGroupResource_change(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.SkipIfCobblerVersionLessThan(t, 4, 0, 0)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDistroGroupResourceChange1,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cobbler_distro_group.foo", "comment", "A distro group"),
+					resource.TestCheckResourceAttr("cobbler_distro_group.foo", "items.#", "1"),
+					resource.TestCheckResourceAttrPair("cobbler_distro_group.foo", "items.0", "cobbler_distro.a", "uid"),
+				),
+			},
+			{
+				// Add a second member and change the comment.
+				Config: testAccDistroGroupResourceChange2,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cobbler_distro_group.foo", "comment", "A distro group updated"),
+					resource.TestCheckResourceAttr("cobbler_distro_group.foo", "items.#", "2"),
+					resource.TestCheckResourceAttrPair("cobbler_distro_group.foo", "items.0", "cobbler_distro.a", "uid"),
+					resource.TestCheckResourceAttrPair("cobbler_distro_group.foo", "items.1", "cobbler_distro.b", "uid"),
+				),
+			},
+			{
+				// Remove the first member, keeping only the second.
+				Config: testAccDistroGroupResourceChange3,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cobbler_distro_group.foo", "items.#", "1"),
+					resource.TestCheckResourceAttrPair("cobbler_distro_group.foo", "items.0", "cobbler_distro.b", "uid"),
+				),
+			},
+			{
+				ResourceName:                         "cobbler_distro_group.foo",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateId:                        "foo-resource-distro-group-change",
+				ImportStateVerifyIdentifierAttribute: "name",
+			},
+		},
+	})
+}
+
+const testAccDistroGroupResourceChangeDistros = `
+resource "cobbler_distro" "a" {
+  name       = "foo-resource-distro-group-change-a"
+  breed      = "ubuntu"
+  os_version = "focal"
+  arch       = "x86_64"
+  kernel     = "/srv/www/cobbler/distro_mirror/Ubuntu-20.04/install/vmlinuz"
+  initrd     = "/srv/www/cobbler/distro_mirror/Ubuntu-20.04/install/initrd.gz"
+}
+
+resource "cobbler_distro" "b" {
+  name       = "foo-resource-distro-group-change-b"
+  breed      = "ubuntu"
+  os_version = "focal"
+  arch       = "x86_64"
+  kernel     = "/srv/www/cobbler/distro_mirror/Ubuntu-20.04/install/vmlinuz"
+  initrd     = "/srv/www/cobbler/distro_mirror/Ubuntu-20.04/install/initrd.gz"
+}
+`
+
+const testAccDistroGroupResourceChange1 = testAccDistroGroupResourceChangeDistros + `
+resource "cobbler_distro_group" "foo" {
+  name    = "foo-resource-distro-group-change"
+  comment = "A distro group"
+  items   = [cobbler_distro.a.uid]
+}
+`
+
+const testAccDistroGroupResourceChange2 = testAccDistroGroupResourceChangeDistros + `
+resource "cobbler_distro_group" "foo" {
+  name    = "foo-resource-distro-group-change"
+  comment = "A distro group updated"
+  items   = [cobbler_distro.a.uid, cobbler_distro.b.uid]
+}
+`
+
+const testAccDistroGroupResourceChange3 = testAccDistroGroupResourceChangeDistros + `
+resource "cobbler_distro_group" "foo" {
+  name    = "foo-resource-distro-group-change"
+  comment = "A distro group updated"
+  items   = [cobbler_distro.b.uid]
+}
+`

--- a/internal/image/data_source.go
+++ b/internal/image/data_source.go
@@ -195,7 +195,17 @@ func (d *ImageDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 		return
 	}
 
-	imagePtr, err := d.client.GetImage(data.Name.ValueString(), false, false)
+	matches, err := d.client.FindImage(map[string]interface{}{"name": data.Name.ValueString()}, false)
+	if err != nil {
+		resp.Diagnostics.AddError("Error resolving Cobbler Image uid", err.Error())
+		return
+	}
+	uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "Image", data.Name.ValueString(), matches, func(i *cobbler.Image) string { return i.Uid })
+	if !ok {
+		return
+	}
+
+	imagePtr, err := d.client.GetImage(uid, false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler Image", err.Error())
 		return

--- a/internal/image/data_source_test.go
+++ b/internal/image/data_source_test.go
@@ -1,6 +1,7 @@
 package image_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/cobbler/terraform-provider-cobbler/internal/acctest"
@@ -24,6 +25,28 @@ func TestAccImageDataSource_basic(t *testing.T) {
 		},
 	})
 }
+
+// TestAccImageDataSource_notFound exercises the zero-match branch of the data source's
+// name-to-uid resolution: looking up a name that doesn't exist on the server must surface a
+// clear "not found" diagnostic instead of a raw client error.
+func TestAccImageDataSource_notFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccImageDataSourceNotFound,
+				ExpectError: regexp.MustCompile(`Cobbler Image not found`),
+			},
+		},
+	})
+}
+
+const testAccImageDataSourceNotFound = `
+data "cobbler_image" "notfound" {
+  name = "does-not-exist-image-data-source"
+}
+`
 
 const testAccImageDataSourceBasic = `
 resource "cobbler_image" "foo" {

--- a/internal/image/resource.go
+++ b/internal/image/resource.go
@@ -345,7 +345,20 @@ func (r *ImageResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	image, err := r.client.GetImage(data.Name.ValueString(), false, false)
+	if data.UID.IsNull() || data.UID.IsUnknown() || data.UID.ValueString() == "" {
+		matches, err := r.client.FindImage(map[string]interface{}{"name": data.Name.ValueString()}, false)
+		if err != nil {
+			resp.Diagnostics.AddError("Error resolving Cobbler Image uid", err.Error())
+			return
+		}
+		uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "Image", data.Name.ValueString(), matches, func(i *cobbler.Image) string { return i.Uid })
+		if !ok {
+			return
+		}
+		data.UID = types.StringValue(uid)
+	}
+
+	image, err := r.client.GetImage(data.UID.ValueString(), false, false)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			resp.State.RemoveResource(ctx)
@@ -382,7 +395,7 @@ func (r *ImageResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		return
 	}
 
-	updatedImage, err := r.client.GetImage(data.Name.ValueString(), false, false)
+	updatedImage, err := r.client.GetImage(data.UID.ValueString(), false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler Image after update", err.Error())
 		return
@@ -405,7 +418,7 @@ func (r *ImageResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 
 	tflog.Debug(ctx, "Cobbler Image: Delete", map[string]interface{}{"name": data.Name.ValueString()})
 
-	if err := r.client.DeleteImage(data.Name.ValueString()); err != nil {
+	if err := r.client.DeleteImage(data.UID.ValueString()); err != nil {
 		resp.Diagnostics.AddError("Error deleting Cobbler Image", err.Error())
 	}
 }

--- a/internal/image/resource_test.go
+++ b/internal/image/resource_test.go
@@ -1,6 +1,7 @@
 package image_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/cobbler/terraform-provider-cobbler/internal/acctest"
@@ -89,6 +90,41 @@ const testAccImageResourceBasic = `
 resource "cobbler_image" "foo" {
   name       = "foo-resource-image-basic"
   file       = "/var/www/cobbler/images/foo-basic.iso"
+  breed      = "ubuntu"
+  os_version = "focal"
+  arch       = "x86_64"
+  image_type = "iso"
+}
+`
+
+// TestAccImageResource_importNotFound exercises the zero-match branch of the resource's
+// post-import name-to-uid resolution fallback: importing an ID that doesn't match any Image on
+// the server must surface a clear "not found" diagnostic instead of a raw client error.
+func TestAccImageResource_importNotFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageResourceImportNotFound,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cobbler_image.notfound", "name", "foo-resource-image-import-not-found"),
+				),
+			},
+			{
+				ResourceName:  "cobbler_image.notfound",
+				ImportState:   true,
+				ImportStateId: "does-not-exist-image-resource",
+				ExpectError:   regexp.MustCompile(`Cobbler Image not found`),
+			},
+		},
+	})
+}
+
+const testAccImageResourceImportNotFound = `
+resource "cobbler_image" "notfound" {
+  name       = "foo-resource-image-import-not-found"
+  file       = "/var/www/cobbler/images/foo-import-not-found.iso"
   breed      = "ubuntu"
   os_version = "focal"
   arch       = "x86_64"

--- a/internal/menu/data_source.go
+++ b/internal/menu/data_source.go
@@ -100,7 +100,17 @@ func (d *MenuDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		return
 	}
 
-	menuPtr, err := d.client.GetMenu(data.Name.ValueString(), false, false)
+	matches, err := d.client.FindMenu(map[string]interface{}{"name": data.Name.ValueString()}, false)
+	if err != nil {
+		resp.Diagnostics.AddError("Error resolving Cobbler Menu uid", err.Error())
+		return
+	}
+	uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "Menu", data.Name.ValueString(), matches, func(m *cobbler.Menu) string { return m.Uid })
+	if !ok {
+		return
+	}
+
+	menuPtr, err := d.client.GetMenu(uid, false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler Menu", err.Error())
 		return

--- a/internal/menu/data_source_test.go
+++ b/internal/menu/data_source_test.go
@@ -1,6 +1,7 @@
 package menu_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/cobbler/terraform-provider-cobbler/internal/acctest"
@@ -22,6 +23,28 @@ func TestAccMenuDataSource_basic(t *testing.T) {
 		},
 	})
 }
+
+// TestAccMenuDataSource_notFound exercises the zero-match branch of the data source's
+// name-to-uid resolution: looking up a name that doesn't exist on the server must surface a
+// clear "not found" diagnostic instead of a raw client error.
+func TestAccMenuDataSource_notFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccMenuDataSourceNotFound,
+				ExpectError: regexp.MustCompile(`Cobbler Menu not found`),
+			},
+		},
+	})
+}
+
+const testAccMenuDataSourceNotFound = `
+data "cobbler_menu" "notfound" {
+  name = "does-not-exist-menu-data-source"
+}
+`
 
 const testAccMenuDataSourceBasic = `
 resource "cobbler_menu" "foo" {

--- a/internal/menu/resource.go
+++ b/internal/menu/resource.go
@@ -187,7 +187,20 @@ func (r *MenuResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	menu, err := r.client.GetMenu(data.Name.ValueString(), false, false)
+	if data.UID.IsNull() || data.UID.IsUnknown() || data.UID.ValueString() == "" {
+		matches, err := r.client.FindMenu(map[string]interface{}{"name": data.Name.ValueString()}, false)
+		if err != nil {
+			resp.Diagnostics.AddError("Error resolving Cobbler Menu uid", err.Error())
+			return
+		}
+		uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "Menu", data.Name.ValueString(), matches, func(m *cobbler.Menu) string { return m.Uid })
+		if !ok {
+			return
+		}
+		data.UID = types.StringValue(uid)
+	}
+
+	menu, err := r.client.GetMenu(data.UID.ValueString(), false, false)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			resp.State.RemoveResource(ctx)
@@ -224,7 +237,7 @@ func (r *MenuResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	updatedMenu, err := r.client.GetMenu(data.Name.ValueString(), false, false)
+	updatedMenu, err := r.client.GetMenu(data.UID.ValueString(), false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler Menu after update", err.Error())
 		return
@@ -247,7 +260,7 @@ func (r *MenuResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 	tflog.Debug(ctx, "Cobbler Menu: Delete", map[string]interface{}{"name": data.Name.ValueString()})
 
-	if err := r.client.DeleteMenu(data.Name.ValueString()); err != nil {
+	if err := r.client.DeleteMenu(data.UID.ValueString()); err != nil {
 		resp.Diagnostics.AddError("Error deleting Cobbler Menu", err.Error())
 	}
 }

--- a/internal/menu/resource_test.go
+++ b/internal/menu/resource_test.go
@@ -1,6 +1,7 @@
 package menu_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/cobbler/terraform-provider-cobbler/internal/acctest"
@@ -81,6 +82,36 @@ func TestAccMenuResource_inherit(t *testing.T) {
 		},
 	})
 }
+
+// TestAccMenuResource_importNotFound exercises the zero-match branch of the resource's
+// post-import name-to-uid resolution fallback: importing an ID that doesn't match any Menu on
+// the server must surface a clear "not found" diagnostic instead of a raw client error.
+func TestAccMenuResource_importNotFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMenuResourceImportNotFound,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cobbler_menu.notfound", "name", "foo-resource-menu-import-not-found"),
+				),
+			},
+			{
+				ResourceName:  "cobbler_menu.notfound",
+				ImportState:   true,
+				ImportStateId: "does-not-exist-menu-resource",
+				ExpectError:   regexp.MustCompile(`Cobbler Menu not found`),
+			},
+		},
+	})
+}
+
+const testAccMenuResourceImportNotFound = `
+resource "cobbler_menu" "notfound" {
+  name = "foo-resource-menu-import-not-found"
+}
+`
 
 const testAccMenuResourceBasic = `
 resource "cobbler_menu" "foo" {

--- a/internal/network_interface/convert.go
+++ b/internal/network_interface/convert.go
@@ -206,6 +206,7 @@ func modelToInterface(ctx context.Context, data networkInterfaceResourceModel, d
 // interfaceToModel populates a resource model from a NetworkInterface.
 func interfaceToModel(ctx context.Context, iface cobbler.NetworkInterface, data *networkInterfaceResourceModel, diags *diag.Diagnostics) {
 	data.Name = types.StringValue(iface.Name)
+	data.UID = types.StringValue(iface.Uid)
 	data.System = types.StringValue(iface.SystemUid)
 	data.SystemName = types.StringValue(iface.SystemName)
 	data.Comment = types.StringValue(iface.Comment)
@@ -229,6 +230,7 @@ func interfaceToModel(ctx context.Context, iface cobbler.NetworkInterface, data 
 // interfaceToDataSourceModel populates a data source model from a NetworkInterface.
 func interfaceToDataSourceModel(ctx context.Context, iface cobbler.NetworkInterface, data *networkInterfaceDataSourceModel, diags *diag.Diagnostics) {
 	data.Name = types.StringValue(iface.Name)
+	data.UID = types.StringValue(iface.Uid)
 	data.System = types.StringValue(iface.SystemUid)
 	data.SystemName = types.StringValue(iface.SystemName)
 	data.Comment = types.StringValue(iface.Comment)

--- a/internal/network_interface/data_source.go
+++ b/internal/network_interface/data_source.go
@@ -32,6 +32,7 @@ func (d *NetworkInterfaceDataSource) Schema(_ context.Context, _ datasource.Sche
 				Description: "The interface's name (globally unique across all systems, since network interfaces are a flat, top-level Cobbler collection).",
 				Required:    true,
 			},
+			"uid":              dsschema.StringAttribute{Description: "Server-assigned UID for this network interface.", Computed: true},
 			"system":           dsschema.StringAttribute{Description: "The UID of the parent system.", Computed: true},
 			"system_name":      dsschema.StringAttribute{Description: "The name of the parent system.", Computed: true},
 			"comment":          dsschema.StringAttribute{Description: "Free form text description.", Computed: true},
@@ -108,7 +109,17 @@ func (d *NetworkInterfaceDataSource) Read(ctx context.Context, req datasource.Re
 		return
 	}
 
-	iface, err := d.client.GetNetworkInterface(data.Name.ValueString(), false, false)
+	matches, err := d.client.FindNetworkInterface(map[string]interface{}{"name": data.Name.ValueString()}, false)
+	if err != nil {
+		resp.Diagnostics.AddError("Error resolving Cobbler NetworkInterface uid", err.Error())
+		return
+	}
+	uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "NetworkInterface", data.Name.ValueString(), matches, func(n *cobbler.NetworkInterface) string { return n.Uid })
+	if !ok {
+		return
+	}
+
+	iface, err := d.client.GetNetworkInterface(uid, false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler NetworkInterface", err.Error())
 		return

--- a/internal/network_interface/data_source_model.go
+++ b/internal/network_interface/data_source_model.go
@@ -4,6 +4,7 @@ import "github.com/hashicorp/terraform-plugin-framework/types"
 
 type networkInterfaceDataSourceModel struct {
 	Name            types.String `tfsdk:"name"`
+	UID             types.String `tfsdk:"uid"`
 	System          types.String `tfsdk:"system"`
 	SystemName      types.String `tfsdk:"system_name"`
 	Comment         types.String `tfsdk:"comment"`

--- a/internal/network_interface/data_source_test.go
+++ b/internal/network_interface/data_source_test.go
@@ -1,6 +1,7 @@
 package network_interface_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/cobbler/terraform-provider-cobbler/internal/acctest"
@@ -26,6 +27,31 @@ func TestAccNetworkInterfaceDataSource_basic(t *testing.T) {
 		},
 	})
 }
+
+// TestAccNetworkInterfaceDataSource_notFound exercises the zero-match branch of the data
+// source's name-to-uid resolution: looking up a name that doesn't exist on the server must
+// surface a clear "not found" diagnostic instead of a raw client error.
+func TestAccNetworkInterfaceDataSource_notFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.SkipIfCobblerVersionLessThan(t, 4, 0, 0)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccNetworkInterfaceDataSourceNotFound,
+				ExpectError: regexp.MustCompile(`Cobbler NetworkInterface not found`),
+			},
+		},
+	})
+}
+
+const testAccNetworkInterfaceDataSourceNotFound = `
+data "cobbler_network_interface" "notfound" {
+  name = "does-not-exist-network-interface-data-source"
+}
+`
 
 const testAccNetworkInterfaceDataSourceBasic = testAccNetworkInterfaceDistroProfileSystem + `
 resource "cobbler_system" "foo" {

--- a/internal/network_interface/resource.go
+++ b/internal/network_interface/resource.go
@@ -47,6 +47,13 @@ func (r *NetworkInterfaceResource) Schema(_ context.Context, _ resource.SchemaRe
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"uid": schema.StringAttribute{
+				Description: "Server-assigned UID for this network interface.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"system": schema.StringAttribute{
 				Description: "The Cobbler UID of the parent system. Use `cobbler_system.foo.uid`. Changing this forces a new resource.",
 				Required:    true,
@@ -374,7 +381,20 @@ func (r *NetworkInterfaceResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
-	iface, err := r.client.GetNetworkInterface(data.Name.ValueString(), false, false)
+	if data.UID.IsNull() || data.UID.IsUnknown() || data.UID.ValueString() == "" {
+		matches, err := r.client.FindNetworkInterface(map[string]interface{}{"name": data.Name.ValueString()}, false)
+		if err != nil {
+			resp.Diagnostics.AddError("Error resolving Cobbler NetworkInterface uid", err.Error())
+			return
+		}
+		uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "NetworkInterface", data.Name.ValueString(), matches, func(n *cobbler.NetworkInterface) string { return n.Uid })
+		if !ok {
+			return
+		}
+		data.UID = types.StringValue(uid)
+	}
+
+	iface, err := r.client.GetNetworkInterface(data.UID.ValueString(), false, false)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			resp.State.RemoveResource(ctx)
@@ -416,7 +436,7 @@ func (r *NetworkInterfaceResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
-	updated, err := r.client.GetNetworkInterface(iface.Name, false, false)
+	updated, err := r.client.GetNetworkInterface(data.UID.ValueString(), false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler NetworkInterface after update", err.Error())
 		return
@@ -444,7 +464,7 @@ func (r *NetworkInterfaceResource) Delete(ctx context.Context, req resource.Dele
 
 	tflog.Debug(ctx, "Cobbler NetworkInterface: Delete", map[string]interface{}{"name": data.Name.ValueString()})
 
-	if err := r.client.DeleteNetworkInterface(data.Name.ValueString()); err != nil {
+	if err := r.client.DeleteNetworkInterface(data.UID.ValueString()); err != nil {
 		resp.Diagnostics.AddError("Error deleting Cobbler NetworkInterface", err.Error())
 	}
 }

--- a/internal/network_interface/resource_model.go
+++ b/internal/network_interface/resource_model.go
@@ -4,6 +4,7 @@ import "github.com/hashicorp/terraform-plugin-framework/types"
 
 type networkInterfaceResourceModel struct {
 	Name            types.String `tfsdk:"name"`
+	UID             types.String `tfsdk:"uid"`
 	System          types.String `tfsdk:"system"`
 	SystemName      types.String `tfsdk:"system_name"`
 	Comment         types.String `tfsdk:"comment"`

--- a/internal/network_interface/resource_test.go
+++ b/internal/network_interface/resource_test.go
@@ -1,6 +1,7 @@
 package network_interface_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/cobbler/terraform-provider-cobbler/internal/acctest"
@@ -60,6 +61,47 @@ func TestAccNetworkInterfaceResource_change(t *testing.T) {
 		},
 	})
 }
+
+// TestAccNetworkInterfaceResource_importNotFound exercises the zero-match branch of the
+// resource's post-import name-to-uid resolution fallback: importing an ID that doesn't match
+// any NetworkInterface on the server must surface a clear "not found" diagnostic instead of a
+// raw client error.
+func TestAccNetworkInterfaceResource_importNotFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.SkipIfCobblerVersionLessThan(t, 4, 0, 0)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkInterfaceResourceImportNotFound,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cobbler_network_interface.notfound", "name", "eth0-foo-resource-network-interface-import-not-found"),
+				),
+			},
+			{
+				ResourceName:  "cobbler_network_interface.notfound",
+				ImportState:   true,
+				ImportStateId: "does-not-exist-network-interface-resource",
+				ExpectError:   regexp.MustCompile(`Cobbler NetworkInterface not found`),
+			},
+		},
+	})
+}
+
+const testAccNetworkInterfaceResourceImportNotFound = testAccNetworkInterfaceDistroProfileSystem + `
+resource "cobbler_system" "notfound" {
+  name    = "foo-resource-network-interface-import-not-found"
+  profile = cobbler_profile.foo.uid
+}
+
+resource "cobbler_network_interface" "notfound" {
+  name        = "eth0-${cobbler_system.notfound.name}"
+  system      = cobbler_system.notfound.uid
+  mac_address = "aa:bb:cc:dd:ee:00"
+}
+`
 
 const testAccNetworkInterfaceDistroProfileSystem = `
 resource "cobbler_distro" "foo" {

--- a/internal/profile/data_source.go
+++ b/internal/profile/data_source.go
@@ -281,7 +281,17 @@ func (d *ProfileDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	profilePtr, err := d.client.GetProfile(data.Name.ValueString(), false, false)
+	matches, err := d.client.FindProfile(map[string]interface{}{"name": data.Name.ValueString()}, false)
+	if err != nil {
+		resp.Diagnostics.AddError("Error resolving Cobbler Profile uid", err.Error())
+		return
+	}
+	uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "Profile", data.Name.ValueString(), matches, func(p *cobbler.Profile) string { return p.Uid })
+	if !ok {
+		return
+	}
+
+	profilePtr, err := d.client.GetProfile(uid, false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler Profile", err.Error())
 		return

--- a/internal/profile/data_source_test.go
+++ b/internal/profile/data_source_test.go
@@ -1,6 +1,7 @@
 package profile_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/cobbler/terraform-provider-cobbler/internal/acctest"
@@ -22,6 +23,28 @@ func TestAccProfileDataSource_basic(t *testing.T) {
 		},
 	})
 }
+
+// TestAccProfileDataSource_notFound exercises the zero-match branch of the data source's
+// name-to-uid resolution: looking up a name that doesn't exist on the server must surface a
+// clear "not found" diagnostic instead of a raw client error.
+func TestAccProfileDataSource_notFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.SkipIfCobblerVersionLessThan(t, 3, 3, 5) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccProfileDataSourceNotFound,
+				ExpectError: regexp.MustCompile(`Cobbler Profile not found`),
+			},
+		},
+	})
+}
+
+const testAccProfileDataSourceNotFound = `
+data "cobbler_profile" "notfound" {
+  name = "does-not-exist-profile-data-source"
+}
+`
 
 const testAccProfileDataSourceBasic = `
 resource "cobbler_distro" "foo" {

--- a/internal/profile/resource.go
+++ b/internal/profile/resource.go
@@ -485,7 +485,20 @@ func (r *ProfileResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	profile, err := r.client.GetProfile(data.Name.ValueString(), false, false)
+	if data.UID.IsNull() || data.UID.IsUnknown() || data.UID.ValueString() == "" {
+		matches, err := r.client.FindProfile(map[string]interface{}{"name": data.Name.ValueString()}, false)
+		if err != nil {
+			resp.Diagnostics.AddError("Error resolving Cobbler Profile uid", err.Error())
+			return
+		}
+		uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "Profile", data.Name.ValueString(), matches, func(p *cobbler.Profile) string { return p.Uid })
+		if !ok {
+			return
+		}
+		data.UID = types.StringValue(uid)
+	}
+
+	profile, err := r.client.GetProfile(data.UID.ValueString(), false, false)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			resp.State.RemoveResource(ctx)
@@ -522,7 +535,7 @@ func (r *ProfileResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	updatedProfile, err := r.client.GetProfile(data.Name.ValueString(), false, false)
+	updatedProfile, err := r.client.GetProfile(data.UID.ValueString(), false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler Profile after update", err.Error())
 		return
@@ -545,7 +558,7 @@ func (r *ProfileResource) Delete(ctx context.Context, req resource.DeleteRequest
 
 	tflog.Debug(ctx, "Cobbler Profile: Delete", map[string]interface{}{"name": data.Name.ValueString()})
 
-	if err := r.client.DeleteProfile(data.Name.ValueString()); err != nil {
+	if err := r.client.DeleteProfile(data.UID.ValueString()); err != nil {
 		resp.Diagnostics.AddError("Error deleting Cobbler Profile", err.Error())
 	}
 }

--- a/internal/profile/resource_test.go
+++ b/internal/profile/resource_test.go
@@ -1,6 +1,7 @@
 package profile_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/cobbler/terraform-provider-cobbler/internal/acctest"
@@ -57,6 +58,46 @@ func TestAccProfileResource_change(t *testing.T) {
 		},
 	})
 }
+
+// TestAccProfileResource_importNotFound exercises the zero-match branch of the resource's
+// post-import name-to-uid resolution fallback: importing an ID that doesn't match any Profile
+// on the server must surface a clear "not found" diagnostic instead of a raw client error.
+func TestAccProfileResource_importNotFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.SkipIfCobblerVersionLessThan(t, 3, 3, 5) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProfileResourceImportNotFound,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cobbler_profile.notfound", "name", "foo-resource-profile-import-not-found"),
+				),
+			},
+			{
+				ResourceName:  "cobbler_profile.notfound",
+				ImportState:   true,
+				ImportStateId: "does-not-exist-profile-resource",
+				ExpectError:   regexp.MustCompile(`Cobbler Profile not found`),
+			},
+		},
+	})
+}
+
+const testAccProfileResourceImportNotFound = `
+resource "cobbler_distro" "notfound" {
+  name       = "foo-resource-profile-import-not-found"
+  breed      = "ubuntu"
+  os_version = "focal"
+  arch       = "x86_64"
+  kernel     = "/srv/www/cobbler/distro_mirror/Ubuntu-20.04/install/vmlinuz"
+  initrd     = "/srv/www/cobbler/distro_mirror/Ubuntu-20.04/install/initrd.gz"
+}
+
+resource "cobbler_profile" "notfound" {
+  name   = "foo-resource-profile-import-not-found"
+  distro = cobbler_distro.notfound.uid
+}
+`
 
 const testAccProfileResourceBasic = `
 resource "cobbler_distro" "foo" {

--- a/internal/profile_group/data_source.go
+++ b/internal/profile_group/data_source.go
@@ -29,6 +29,7 @@ func (d *ProfileGroupDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 		Description: "Use this data source to look up a Cobbler profile group (4.0.0+).",
 		Attributes: map[string]dsschema.Attribute{
 			"name":    dsschema.StringAttribute{Description: "Name of the group.", Required: true},
+			"uid":     dsschema.StringAttribute{Description: "Server-assigned UID for this profile group.", Computed: true},
 			"comment": dsschema.StringAttribute{Description: "Free form text description.", Computed: true},
 			"items":   dsschema.ListAttribute{Description: "Distro names in the group.", Computed: true, ElementType: types.StringType},
 		},
@@ -55,7 +56,17 @@ func (d *ProfileGroupDataSource) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
-	g, err := d.client.GetProfileGroup(data.Name.ValueString(), false, false)
+	matches, err := d.client.FindProfileGroup(map[string]interface{}{"name": data.Name.ValueString()}, false)
+	if err != nil {
+		resp.Diagnostics.AddError("Error resolving Cobbler ProfileGroup uid", err.Error())
+		return
+	}
+	uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "ProfileGroup", data.Name.ValueString(), matches, func(pg *cobbler.ProfileGroup) string { return pg.Uid })
+	if !ok {
+		return
+	}
+
+	g, err := d.client.GetProfileGroup(uid, false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler ProfileGroup", err.Error())
 		return

--- a/internal/profile_group/data_source.go
+++ b/internal/profile_group/data_source.go
@@ -31,7 +31,7 @@ func (d *ProfileGroupDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 			"name":    dsschema.StringAttribute{Description: "Name of the group.", Required: true},
 			"uid":     dsschema.StringAttribute{Description: "Server-assigned UID for this profile group.", Computed: true},
 			"comment": dsschema.StringAttribute{Description: "Free form text description.", Computed: true},
-			"items":   dsschema.ListAttribute{Description: "Distro names in the group.", Computed: true, ElementType: types.StringType},
+			"items":   dsschema.ListAttribute{Description: "Profile UIDs in the group.", Computed: true, ElementType: types.StringType},
 		},
 	}
 }

--- a/internal/profile_group/data_source_model.go
+++ b/internal/profile_group/data_source_model.go
@@ -4,6 +4,7 @@ import "github.com/hashicorp/terraform-plugin-framework/types"
 
 type profileGroupDataSourceModel struct {
 	Name    types.String `tfsdk:"name"`
+	UID     types.String `tfsdk:"uid"`
 	Comment types.String `tfsdk:"comment"`
 	Items   types.List   `tfsdk:"items"`
 }

--- a/internal/profile_group/data_source_test.go
+++ b/internal/profile_group/data_source_test.go
@@ -1,6 +1,7 @@
 package profile_group_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/cobbler/terraform-provider-cobbler/internal/acctest"
@@ -24,6 +25,31 @@ func TestAccProfileGroupDataSource_basic(t *testing.T) {
 		},
 	})
 }
+
+// TestAccProfileGroupDataSource_notFound exercises the zero-match branch of the data source's
+// name-to-uid resolution: looking up a name that doesn't exist on the server must surface a
+// clear "not found" diagnostic instead of a raw client error.
+func TestAccProfileGroupDataSource_notFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.SkipIfCobblerVersionLessThan(t, 4, 0, 0)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccProfileGroupDataSourceNotFound,
+				ExpectError: regexp.MustCompile(`Cobbler ProfileGroup not found`),
+			},
+		},
+	})
+}
+
+const testAccProfileGroupDataSourceNotFound = `
+data "cobbler_profile_group" "notfound" {
+  name = "does-not-exist-profile-group-data-source"
+}
+`
 
 const testAccProfileGroupDataSourceBasic = `
 resource "cobbler_profile_group" "foo" {

--- a/internal/profile_group/resource.go
+++ b/internal/profile_group/resource.go
@@ -59,7 +59,7 @@ func (r *ProfileGroupResource) Schema(_ context.Context, _ resource.SchemaReques
 				},
 			},
 			"items": schema.ListAttribute{
-				Description: "Names of the distros belonging to this group.",
+				Description: "UIDs of the profiles belonging to this group.",
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,

--- a/internal/profile_group/resource.go
+++ b/internal/profile_group/resource.go
@@ -43,6 +43,13 @@ func (r *ProfileGroupResource) Schema(_ context.Context, _ resource.SchemaReques
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"uid": schema.StringAttribute{
+				Description: "Server-assigned UID for this profile group.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"comment": schema.StringAttribute{
 				Description: "Free form text description.",
 				Optional:    true,
@@ -95,6 +102,7 @@ func modelToGroup(ctx context.Context, data profileGroupResourceModel, diags *di
 
 func groupToModel(ctx context.Context, g cobbler.ProfileGroup, data *profileGroupResourceModel, diags *diag.Diagnostics) {
 	data.Name = types.StringValue(g.Name)
+	data.UID = types.StringValue(g.Uid)
 	data.Comment = types.StringValue(g.Comment)
 
 	items := g.Members
@@ -108,6 +116,7 @@ func groupToModel(ctx context.Context, g cobbler.ProfileGroup, data *profileGrou
 
 func groupToDataSourceModel(ctx context.Context, g cobbler.ProfileGroup, data *profileGroupDataSourceModel, diags *diag.Diagnostics) {
 	data.Name = types.StringValue(g.Name)
+	data.UID = types.StringValue(g.Uid)
 	data.Comment = types.StringValue(g.Comment)
 
 	items := g.Members
@@ -153,7 +162,20 @@ func (r *ProfileGroupResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	g, err := r.client.GetProfileGroup(data.Name.ValueString(), false, false)
+	if data.UID.IsNull() || data.UID.IsUnknown() || data.UID.ValueString() == "" {
+		matches, err := r.client.FindProfileGroup(map[string]interface{}{"name": data.Name.ValueString()}, false)
+		if err != nil {
+			resp.Diagnostics.AddError("Error resolving Cobbler ProfileGroup uid", err.Error())
+			return
+		}
+		uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "ProfileGroup", data.Name.ValueString(), matches, func(pg *cobbler.ProfileGroup) string { return pg.Uid })
+		if !ok {
+			return
+		}
+		data.UID = types.StringValue(uid)
+	}
+
+	g, err := r.client.GetProfileGroup(data.UID.ValueString(), false, false)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			resp.State.RemoveResource(ctx)
@@ -189,7 +211,7 @@ func (r *ProfileGroupResource) Update(ctx context.Context, req resource.UpdateRe
 		return
 	}
 
-	updated, err := r.client.GetProfileGroup(g.Name, false, false)
+	updated, err := r.client.GetProfileGroup(data.UID.ValueString(), false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler ProfileGroup after update", err.Error())
 		return
@@ -211,7 +233,7 @@ func (r *ProfileGroupResource) Delete(ctx context.Context, req resource.DeleteRe
 
 	tflog.Debug(ctx, "Cobbler ProfileGroup: Delete", map[string]interface{}{"name": data.Name.ValueString()})
 
-	if err := r.client.DeleteProfileGroup(data.Name.ValueString()); err != nil {
+	if err := r.client.DeleteProfileGroup(data.UID.ValueString()); err != nil {
 		resp.Diagnostics.AddError("Error deleting Cobbler ProfileGroup", err.Error())
 	}
 }

--- a/internal/profile_group/resource_model.go
+++ b/internal/profile_group/resource_model.go
@@ -4,6 +4,7 @@ import "github.com/hashicorp/terraform-plugin-framework/types"
 
 type profileGroupResourceModel struct {
 	Name    types.String `tfsdk:"name"`
+	UID     types.String `tfsdk:"uid"`
 	Comment types.String `tfsdk:"comment"`
 	Items   types.List   `tfsdk:"items"`
 }

--- a/internal/profile_group/resource_test.go
+++ b/internal/profile_group/resource_test.go
@@ -39,3 +39,95 @@ resource "cobbler_profile_group" "foo" {
   comment = "A profile group"
 }
 `
+
+// TestAccProfileGroupResource_change exercises the Update lifecycle: changing the
+// comment and adding/removing members from the group's "items" list.
+func TestAccProfileGroupResource_change(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.SkipIfCobblerVersionLessThan(t, 4, 0, 0)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProfileGroupResourceChange1,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cobbler_profile_group.foo", "comment", "A profile group"),
+					resource.TestCheckResourceAttr("cobbler_profile_group.foo", "items.#", "1"),
+					resource.TestCheckResourceAttrPair("cobbler_profile_group.foo", "items.0", "cobbler_profile.a", "uid"),
+				),
+			},
+			{
+				// Add a second member and change the comment.
+				Config: testAccProfileGroupResourceChange2,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cobbler_profile_group.foo", "comment", "A profile group updated"),
+					resource.TestCheckResourceAttr("cobbler_profile_group.foo", "items.#", "2"),
+					resource.TestCheckResourceAttrPair("cobbler_profile_group.foo", "items.0", "cobbler_profile.a", "uid"),
+					resource.TestCheckResourceAttrPair("cobbler_profile_group.foo", "items.1", "cobbler_profile.b", "uid"),
+				),
+			},
+			{
+				// Remove the first member, keeping only the second.
+				Config: testAccProfileGroupResourceChange3,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cobbler_profile_group.foo", "items.#", "1"),
+					resource.TestCheckResourceAttrPair("cobbler_profile_group.foo", "items.0", "cobbler_profile.b", "uid"),
+				),
+			},
+			{
+				ResourceName:                         "cobbler_profile_group.foo",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateId:                        "foo-resource-profile-group-change",
+				ImportStateVerifyIdentifierAttribute: "name",
+			},
+		},
+	})
+}
+
+const testAccProfileGroupResourceChangeProfiles = `
+resource "cobbler_distro" "foo" {
+  name       = "foo-resource-profile-group-change"
+  breed      = "ubuntu"
+  os_version = "focal"
+  arch       = "x86_64"
+  kernel     = "/srv/www/cobbler/distro_mirror/Ubuntu-20.04/install/vmlinuz"
+  initrd     = "/srv/www/cobbler/distro_mirror/Ubuntu-20.04/install/initrd.gz"
+}
+
+resource "cobbler_profile" "a" {
+  name   = "foo-resource-profile-group-change-a"
+  distro = cobbler_distro.foo.uid
+}
+
+resource "cobbler_profile" "b" {
+  name   = "foo-resource-profile-group-change-b"
+  distro = cobbler_distro.foo.uid
+}
+`
+
+const testAccProfileGroupResourceChange1 = testAccProfileGroupResourceChangeProfiles + `
+resource "cobbler_profile_group" "foo" {
+  name    = "foo-resource-profile-group-change"
+  comment = "A profile group"
+  items   = [cobbler_profile.a.uid]
+}
+`
+
+const testAccProfileGroupResourceChange2 = testAccProfileGroupResourceChangeProfiles + `
+resource "cobbler_profile_group" "foo" {
+  name    = "foo-resource-profile-group-change"
+  comment = "A profile group updated"
+  items   = [cobbler_profile.a.uid, cobbler_profile.b.uid]
+}
+`
+
+const testAccProfileGroupResourceChange3 = testAccProfileGroupResourceChangeProfiles + `
+resource "cobbler_profile_group" "foo" {
+  name    = "foo-resource-profile-group-change"
+  comment = "A profile group updated"
+  items   = [cobbler_profile.b.uid]
+}
+`

--- a/internal/repo/data_source.go
+++ b/internal/repo/data_source.go
@@ -33,6 +33,10 @@ func (d *RepoDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, r
 				Description: "The name of the repo.",
 				Required:    true,
 			},
+			"uid": schema.StringAttribute{
+				Description: "Server-assigned UID for this repo.",
+				Computed:    true,
+			},
 			"arch": schema.StringAttribute{
 				Description: "The architecture of the repo.",
 				Computed:    true,
@@ -138,13 +142,24 @@ func (d *RepoDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		return
 	}
 
-	repo, err := d.client.GetRepo(data.Name.ValueString(), false, false)
+	matches, err := d.client.FindRepo(map[string]interface{}{"name": data.Name.ValueString()}, false)
+	if err != nil {
+		resp.Diagnostics.AddError("Error resolving Cobbler Repo uid", err.Error())
+		return
+	}
+	uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "Repo", data.Name.ValueString(), matches, func(rp *cobbler.Repo) string { return rp.Uid })
+	if !ok {
+		return
+	}
+
+	repo, err := d.client.GetRepo(uid, false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler Repo", err.Error())
 		return
 	}
 
 	data.Name = types.StringValue(repo.Name)
+	data.UID = types.StringValue(repo.Uid)
 	data.Arch = types.StringValue(repo.Arch)
 	data.Breed = types.StringValue(repo.Breed)
 	data.Comment = types.StringValue(repo.Comment)

--- a/internal/repo/data_source_model.go
+++ b/internal/repo/data_source_model.go
@@ -4,6 +4,7 @@ import "github.com/hashicorp/terraform-plugin-framework/types"
 
 type repoDataSourceModel struct {
 	Name            types.String `tfsdk:"name"`
+	UID             types.String `tfsdk:"uid"`
 	AptComponents   types.List   `tfsdk:"apt_components"`
 	AptDists        types.List   `tfsdk:"apt_dists"`
 	Arch            types.String `tfsdk:"arch"`

--- a/internal/repo/data_source_test.go
+++ b/internal/repo/data_source_test.go
@@ -1,6 +1,7 @@
 package repo_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/cobbler/terraform-provider-cobbler/internal/acctest"
@@ -23,6 +24,28 @@ func TestAccRepoDataSource_basic(t *testing.T) {
 		},
 	})
 }
+
+// TestAccRepoDataSource_notFound exercises the zero-match branch of the data source's
+// name-to-uid resolution: looking up a name that doesn't exist on the server must surface a
+// clear "not found" diagnostic instead of a raw client error.
+func TestAccRepoDataSource_notFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccRepoDataSourceNotFound,
+				ExpectError: regexp.MustCompile(`Cobbler Repo not found`),
+			},
+		},
+	})
+}
+
+const testAccRepoDataSourceNotFound = `
+data "cobbler_repo" "notfound" {
+  name = "does-not-exist-repo-data-source"
+}
+`
 
 const testAccRepoDataSourceBasic = `
 resource "cobbler_repo" "foo" {

--- a/internal/repo/resource.go
+++ b/internal/repo/resource.go
@@ -47,6 +47,13 @@ func (r *RepoResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"uid": schema.StringAttribute{
+				Description: "Server-assigned UID for this repo.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"arch": schema.StringAttribute{
 				Description: "The architecture of the repo. Valid options are: i386, x86_64, ia64, ppc, ppc64, s390, arm.",
 				Optional:    true,
@@ -243,7 +250,20 @@ func (r *RepoResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	repo, err := r.client.GetRepo(data.Name.ValueString(), false, false)
+	if data.UID.IsNull() || data.UID.IsUnknown() || data.UID.ValueString() == "" {
+		matches, err := r.client.FindRepo(map[string]interface{}{"name": data.Name.ValueString()}, false)
+		if err != nil {
+			resp.Diagnostics.AddError("Error resolving Cobbler Repo uid", err.Error())
+			return
+		}
+		uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "Repo", data.Name.ValueString(), matches, func(rp *cobbler.Repo) string { return rp.Uid })
+		if !ok {
+			return
+		}
+		data.UID = types.StringValue(uid)
+	}
+
+	repo, err := r.client.GetRepo(data.UID.ValueString(), false, false)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			resp.State.RemoveResource(ctx)
@@ -280,7 +300,7 @@ func (r *RepoResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	updatedRepo, err := r.client.GetRepo(data.Name.ValueString(), false, false)
+	updatedRepo, err := r.client.GetRepo(data.UID.ValueString(), false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler Repo after update", err.Error())
 		return
@@ -303,7 +323,7 @@ func (r *RepoResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 
 	tflog.Debug(ctx, "Cobbler Repo: Delete", map[string]interface{}{"name": data.Name.ValueString()})
 
-	if err := r.client.DeleteRepo(data.Name.ValueString()); err != nil {
+	if err := r.client.DeleteRepo(data.UID.ValueString()); err != nil {
 		resp.Diagnostics.AddError("Error deleting Cobbler Repo", err.Error())
 	}
 }
@@ -358,6 +378,7 @@ func modelToRepo(ctx context.Context, data repoResourceModel, diags *diag.Diagno
 // repoToModel populates a repoResourceModel from a cobbler.Repo.
 func repoToModel(ctx context.Context, repo cobbler.Repo, data *repoResourceModel, diags *diag.Diagnostics) {
 	data.Name = types.StringValue(repo.Name)
+	data.UID = types.StringValue(repo.Uid)
 	data.Arch = types.StringValue(repo.Arch)
 	data.Breed = types.StringValue(repo.Breed)
 	data.Comment = types.StringValue(repo.Comment)

--- a/internal/repo/resource_model.go
+++ b/internal/repo/resource_model.go
@@ -4,6 +4,7 @@ import "github.com/hashicorp/terraform-plugin-framework/types"
 
 type repoResourceModel struct {
 	Name            types.String `tfsdk:"name"`
+	UID             types.String `tfsdk:"uid"`
 	AptComponents   types.List   `tfsdk:"apt_components"`
 	AptDists        types.List   `tfsdk:"apt_dists"`
 	Arch            types.String `tfsdk:"arch"`

--- a/internal/repo/resource_test.go
+++ b/internal/repo/resource_test.go
@@ -1,6 +1,7 @@
 package repo_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/cobbler/terraform-provider-cobbler/internal/acctest"
@@ -59,6 +60,41 @@ func TestAccRepoResource_change(t *testing.T) {
 		},
 	})
 }
+
+// TestAccRepoResource_importNotFound exercises the zero-match branch of the resource's
+// post-import name-to-uid resolution fallback: importing an ID that doesn't match any Repo on
+// the server must surface a clear "not found" diagnostic instead of a raw client error.
+func TestAccRepoResource_importNotFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRepoResourceImportNotFound,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cobbler_repo.notfound", "name", "foo-resource-repo-import-not-found"),
+				),
+			},
+			{
+				ResourceName:  "cobbler_repo.notfound",
+				ImportState:   true,
+				ImportStateId: "does-not-exist-repo-resource",
+				ExpectError:   regexp.MustCompile(`Cobbler Repo not found`),
+			},
+		},
+	})
+}
+
+const testAccRepoResourceImportNotFound = `
+resource "cobbler_repo" "notfound" {
+  name           = "foo-resource-repo-import-not-found"
+  breed          = "apt"
+  arch           = "x86_64"
+  apt_components = ["main"]
+  apt_dists      = ["focal"]
+  mirror         = "http://us.archive.ubuntu.com/ubuntu/"
+}
+`
 
 const testAccRepoResourceBasic = `
 resource "cobbler_repo" "foo" {

--- a/internal/system/data_source.go
+++ b/internal/system/data_source.go
@@ -310,7 +310,17 @@ func (d *SystemDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		return
 	}
 
-	systemPtr, err := d.client.GetSystem(data.Name.ValueString(), false, false)
+	matches, err := d.client.FindSystem(map[string]interface{}{"name": data.Name.ValueString()}, false)
+	if err != nil {
+		resp.Diagnostics.AddError("Error resolving Cobbler System uid", err.Error())
+		return
+	}
+	uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "System", data.Name.ValueString(), matches, func(s *cobbler.System) string { return s.Uid })
+	if !ok {
+		return
+	}
+
+	systemPtr, err := d.client.GetSystem(uid, false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler System", err.Error())
 		return

--- a/internal/system/data_source_test.go
+++ b/internal/system/data_source_test.go
@@ -1,6 +1,7 @@
 package system_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/cobbler/terraform-provider-cobbler/internal/acctest"
@@ -22,6 +23,28 @@ func TestAccSystemDataSource_basic(t *testing.T) {
 		},
 	})
 }
+
+// TestAccSystemDataSource_notFound exercises the zero-match branch of the data source's
+// name-to-uid resolution: looking up a name that doesn't exist on the server must surface a
+// clear "not found" diagnostic instead of a raw client error.
+func TestAccSystemDataSource_notFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.SkipIfCobblerVersionLessThan(t, 3, 3, 5) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccSystemDataSourceNotFound,
+				ExpectError: regexp.MustCompile(`Cobbler System not found`),
+			},
+		},
+	})
+}
+
+const testAccSystemDataSourceNotFound = `
+data "cobbler_system" "notfound" {
+  name = "does-not-exist-system-data-source"
+}
+`
 
 const testAccSystemDataSourceBasic = testAccSystemDistroProfile + `
 resource "cobbler_system" "foo" {

--- a/internal/system/resource.go
+++ b/internal/system/resource.go
@@ -533,7 +533,7 @@ func (r *SystemResource) Create(ctx context.Context, req resource.CreateRequest,
 	}
 
 	// Read back the system to get computed values
-	readSystem, err := r.client.GetSystem(newSystem.Name, false, false)
+	readSystem, err := r.client.GetSystem(newSystem.Uid, false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler System after create", err.Error())
 		return
@@ -554,7 +554,20 @@ func (r *SystemResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	system, err := r.client.GetSystem(data.Name.ValueString(), false, false)
+	if data.UID.IsNull() || data.UID.IsUnknown() || data.UID.ValueString() == "" {
+		matches, err := r.client.FindSystem(map[string]interface{}{"name": data.Name.ValueString()}, false)
+		if err != nil {
+			resp.Diagnostics.AddError("Error resolving Cobbler System uid", err.Error())
+			return
+		}
+		uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "System", data.Name.ValueString(), matches, func(s *cobbler.System) string { return s.Uid })
+		if !ok {
+			return
+		}
+		data.UID = types.StringValue(uid)
+	}
+
+	system, err := r.client.GetSystem(data.UID.ValueString(), false, false)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			resp.State.RemoveResource(ctx)
@@ -598,7 +611,7 @@ func (r *SystemResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	// Read back updated system
-	readSystem, err := r.client.GetSystem(plan.Name.ValueString(), false, false)
+	readSystem, err := r.client.GetSystem(plan.UID.ValueString(), false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler System after update", err.Error())
 		return
@@ -621,7 +634,7 @@ func (r *SystemResource) Delete(ctx context.Context, req resource.DeleteRequest,
 
 	tflog.Debug(ctx, "Cobbler System: Delete", map[string]interface{}{"name": data.Name.ValueString()})
 
-	if err := r.client.DeleteSystem(data.Name.ValueString()); err != nil {
+	if err := r.client.DeleteSystem(data.UID.ValueString()); err != nil {
 		resp.Diagnostics.AddError("Error deleting Cobbler System", err.Error())
 	}
 }

--- a/internal/system/resource_test.go
+++ b/internal/system/resource_test.go
@@ -1,6 +1,7 @@
 package system_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/cobbler/terraform-provider-cobbler/internal/acctest"
@@ -58,6 +59,37 @@ func TestAccSystemResource_change(t *testing.T) {
 		},
 	})
 }
+
+// TestAccSystemResource_importNotFound exercises the zero-match branch of the resource's
+// post-import name-to-uid resolution fallback: importing an ID that doesn't match any System
+// on the server must surface a clear "not found" diagnostic instead of a raw client error.
+func TestAccSystemResource_importNotFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.SkipIfCobblerVersionLessThan(t, 3, 3, 5) },
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSystemResourceImportNotFound,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cobbler_system.notfound", "name", "foo-resource-system-import-not-found"),
+				),
+			},
+			{
+				ResourceName:  "cobbler_system.notfound",
+				ImportState:   true,
+				ImportStateId: "does-not-exist-system-resource",
+				ExpectError:   regexp.MustCompile(`Cobbler System not found`),
+			},
+		},
+	})
+}
+
+const testAccSystemResourceImportNotFound = testAccSystemDistroProfile + `
+resource "cobbler_system" "notfound" {
+  name    = "foo-resource-system-import-not-found"
+  profile = cobbler_profile.foo.uid
+}
+`
 
 // testAccSystemDistroProfile is the shared distro+profile config used by system tests.
 const testAccSystemDistroProfile = `

--- a/internal/system_group/data_source.go
+++ b/internal/system_group/data_source.go
@@ -29,6 +29,7 @@ func (d *SystemGroupDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 		Description: "Use this data source to look up a Cobbler system group (4.0.0+).",
 		Attributes: map[string]dsschema.Attribute{
 			"name":    dsschema.StringAttribute{Description: "Name of the group.", Required: true},
+			"uid":     dsschema.StringAttribute{Description: "Server-assigned UID for this system group.", Computed: true},
 			"comment": dsschema.StringAttribute{Description: "Free form text description.", Computed: true},
 			"items":   dsschema.ListAttribute{Description: "Distro names in the group.", Computed: true, ElementType: types.StringType},
 		},
@@ -55,7 +56,17 @@ func (d *SystemGroupDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	g, err := d.client.GetSystemGroup(data.Name.ValueString(), false, false)
+	matches, err := d.client.FindSystemGroup(map[string]interface{}{"name": data.Name.ValueString()}, false)
+	if err != nil {
+		resp.Diagnostics.AddError("Error resolving Cobbler SystemGroup uid", err.Error())
+		return
+	}
+	uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "SystemGroup", data.Name.ValueString(), matches, func(sg *cobbler.SystemGroup) string { return sg.Uid })
+	if !ok {
+		return
+	}
+
+	g, err := d.client.GetSystemGroup(uid, false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler SystemGroup", err.Error())
 		return

--- a/internal/system_group/data_source.go
+++ b/internal/system_group/data_source.go
@@ -31,7 +31,7 @@ func (d *SystemGroupDataSource) Schema(_ context.Context, _ datasource.SchemaReq
 			"name":    dsschema.StringAttribute{Description: "Name of the group.", Required: true},
 			"uid":     dsschema.StringAttribute{Description: "Server-assigned UID for this system group.", Computed: true},
 			"comment": dsschema.StringAttribute{Description: "Free form text description.", Computed: true},
-			"items":   dsschema.ListAttribute{Description: "Distro names in the group.", Computed: true, ElementType: types.StringType},
+			"items":   dsschema.ListAttribute{Description: "System UIDs in the group.", Computed: true, ElementType: types.StringType},
 		},
 	}
 }

--- a/internal/system_group/data_source_model.go
+++ b/internal/system_group/data_source_model.go
@@ -4,6 +4,7 @@ import "github.com/hashicorp/terraform-plugin-framework/types"
 
 type systemGroupDataSourceModel struct {
 	Name    types.String `tfsdk:"name"`
+	UID     types.String `tfsdk:"uid"`
 	Comment types.String `tfsdk:"comment"`
 	Items   types.List   `tfsdk:"items"`
 }

--- a/internal/system_group/data_source_test.go
+++ b/internal/system_group/data_source_test.go
@@ -1,6 +1,7 @@
 package system_group_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/cobbler/terraform-provider-cobbler/internal/acctest"
@@ -24,6 +25,31 @@ func TestAccSystemGroupDataSource_basic(t *testing.T) {
 		},
 	})
 }
+
+// TestAccSystemGroupDataSource_notFound exercises the zero-match branch of the data source's
+// name-to-uid resolution: looking up a name that doesn't exist on the server must surface a
+// clear "not found" diagnostic instead of a raw client error.
+func TestAccSystemGroupDataSource_notFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.SkipIfCobblerVersionLessThan(t, 4, 0, 0)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccSystemGroupDataSourceNotFound,
+				ExpectError: regexp.MustCompile(`Cobbler SystemGroup not found`),
+			},
+		},
+	})
+}
+
+const testAccSystemGroupDataSourceNotFound = `
+data "cobbler_system_group" "notfound" {
+  name = "does-not-exist-system-group-data-source"
+}
+`
 
 const testAccSystemGroupDataSourceBasic = `
 resource "cobbler_system_group" "foo" {

--- a/internal/system_group/resource.go
+++ b/internal/system_group/resource.go
@@ -43,6 +43,13 @@ func (r *SystemGroupResource) Schema(_ context.Context, _ resource.SchemaRequest
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"uid": schema.StringAttribute{
+				Description: "Server-assigned UID for this system group.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"comment": schema.StringAttribute{
 				Description: "Free form text description.",
 				Optional:    true,
@@ -95,6 +102,7 @@ func modelToGroup(ctx context.Context, data systemGroupResourceModel, diags *dia
 
 func groupToModel(ctx context.Context, g cobbler.SystemGroup, data *systemGroupResourceModel, diags *diag.Diagnostics) {
 	data.Name = types.StringValue(g.Name)
+	data.UID = types.StringValue(g.Uid)
 	data.Comment = types.StringValue(g.Comment)
 
 	items := g.Members
@@ -108,6 +116,7 @@ func groupToModel(ctx context.Context, g cobbler.SystemGroup, data *systemGroupR
 
 func groupToDataSourceModel(ctx context.Context, g cobbler.SystemGroup, data *systemGroupDataSourceModel, diags *diag.Diagnostics) {
 	data.Name = types.StringValue(g.Name)
+	data.UID = types.StringValue(g.Uid)
 	data.Comment = types.StringValue(g.Comment)
 
 	items := g.Members
@@ -153,7 +162,20 @@ func (r *SystemGroupResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	g, err := r.client.GetSystemGroup(data.Name.ValueString(), false, false)
+	if data.UID.IsNull() || data.UID.IsUnknown() || data.UID.ValueString() == "" {
+		matches, err := r.client.FindSystemGroup(map[string]interface{}{"name": data.Name.ValueString()}, false)
+		if err != nil {
+			resp.Diagnostics.AddError("Error resolving Cobbler SystemGroup uid", err.Error())
+			return
+		}
+		uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "SystemGroup", data.Name.ValueString(), matches, func(sg *cobbler.SystemGroup) string { return sg.Uid })
+		if !ok {
+			return
+		}
+		data.UID = types.StringValue(uid)
+	}
+
+	g, err := r.client.GetSystemGroup(data.UID.ValueString(), false, false)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			resp.State.RemoveResource(ctx)
@@ -189,7 +211,7 @@ func (r *SystemGroupResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	updated, err := r.client.GetSystemGroup(g.Name, false, false)
+	updated, err := r.client.GetSystemGroup(data.UID.ValueString(), false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler SystemGroup after update", err.Error())
 		return
@@ -211,7 +233,7 @@ func (r *SystemGroupResource) Delete(ctx context.Context, req resource.DeleteReq
 
 	tflog.Debug(ctx, "Cobbler SystemGroup: Delete", map[string]interface{}{"name": data.Name.ValueString()})
 
-	if err := r.client.DeleteSystemGroup(data.Name.ValueString()); err != nil {
+	if err := r.client.DeleteSystemGroup(data.UID.ValueString()); err != nil {
 		resp.Diagnostics.AddError("Error deleting Cobbler SystemGroup", err.Error())
 	}
 }

--- a/internal/system_group/resource.go
+++ b/internal/system_group/resource.go
@@ -59,7 +59,7 @@ func (r *SystemGroupResource) Schema(_ context.Context, _ resource.SchemaRequest
 				},
 			},
 			"items": schema.ListAttribute{
-				Description: "Names of the distros belonging to this group.",
+				Description: "UIDs of the systems belonging to this group.",
 				Optional:    true,
 				Computed:    true,
 				ElementType: types.StringType,

--- a/internal/system_group/resource_model.go
+++ b/internal/system_group/resource_model.go
@@ -4,6 +4,7 @@ import "github.com/hashicorp/terraform-plugin-framework/types"
 
 type systemGroupResourceModel struct {
 	Name    types.String `tfsdk:"name"`
+	UID     types.String `tfsdk:"uid"`
 	Comment types.String `tfsdk:"comment"`
 	Items   types.List   `tfsdk:"items"`
 }

--- a/internal/system_group/resource_test.go
+++ b/internal/system_group/resource_test.go
@@ -39,3 +39,100 @@ resource "cobbler_system_group" "foo" {
   comment = "A system group"
 }
 `
+
+// TestAccSystemGroupResource_change exercises the Update lifecycle: changing the
+// comment and adding/removing members from the group's "items" list.
+func TestAccSystemGroupResource_change(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.SkipIfCobblerVersionLessThan(t, 4, 0, 0)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSystemGroupResourceChange1,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cobbler_system_group.foo", "comment", "A system group"),
+					resource.TestCheckResourceAttr("cobbler_system_group.foo", "items.#", "1"),
+					resource.TestCheckResourceAttrPair("cobbler_system_group.foo", "items.0", "cobbler_system.a", "uid"),
+				),
+			},
+			{
+				// Add a second member and change the comment.
+				Config: testAccSystemGroupResourceChange2,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cobbler_system_group.foo", "comment", "A system group updated"),
+					resource.TestCheckResourceAttr("cobbler_system_group.foo", "items.#", "2"),
+					resource.TestCheckResourceAttrPair("cobbler_system_group.foo", "items.0", "cobbler_system.a", "uid"),
+					resource.TestCheckResourceAttrPair("cobbler_system_group.foo", "items.1", "cobbler_system.b", "uid"),
+				),
+			},
+			{
+				// Remove the first member, keeping only the second.
+				Config: testAccSystemGroupResourceChange3,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cobbler_system_group.foo", "items.#", "1"),
+					resource.TestCheckResourceAttrPair("cobbler_system_group.foo", "items.0", "cobbler_system.b", "uid"),
+				),
+			},
+			{
+				ResourceName:                         "cobbler_system_group.foo",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateId:                        "foo-resource-system-group-change",
+				ImportStateVerifyIdentifierAttribute: "name",
+			},
+		},
+	})
+}
+
+const testAccSystemGroupResourceChangeSystems = `
+resource "cobbler_distro" "foo" {
+  name       = "foo-resource-system-group-change"
+  breed      = "ubuntu"
+  os_version = "focal"
+  arch       = "x86_64"
+  kernel     = "/srv/www/cobbler/distro_mirror/Ubuntu-20.04/install/vmlinuz"
+  initrd     = "/srv/www/cobbler/distro_mirror/Ubuntu-20.04/install/initrd.gz"
+}
+
+resource "cobbler_profile" "foo" {
+  name   = "foo-resource-system-group-change"
+  distro = cobbler_distro.foo.uid
+}
+
+resource "cobbler_system" "a" {
+  name    = "foo-resource-system-group-change-a"
+  profile = cobbler_profile.foo.uid
+}
+
+resource "cobbler_system" "b" {
+  name    = "foo-resource-system-group-change-b"
+  profile = cobbler_profile.foo.uid
+}
+`
+
+const testAccSystemGroupResourceChange1 = testAccSystemGroupResourceChangeSystems + `
+resource "cobbler_system_group" "foo" {
+  name    = "foo-resource-system-group-change"
+  comment = "A system group"
+  items   = [cobbler_system.a.uid]
+}
+`
+
+const testAccSystemGroupResourceChange2 = testAccSystemGroupResourceChangeSystems + `
+resource "cobbler_system_group" "foo" {
+  name    = "foo-resource-system-group-change"
+  comment = "A system group updated"
+  items   = [cobbler_system.a.uid, cobbler_system.b.uid]
+}
+`
+
+const testAccSystemGroupResourceChange3 = testAccSystemGroupResourceChangeSystems + `
+resource "cobbler_system_group" "foo" {
+  name    = "foo-resource-system-group-change"
+  comment = "A system group updated"
+  items   = [cobbler_system.b.uid]
+}
+`

--- a/internal/template/data_source.go
+++ b/internal/template/data_source.go
@@ -29,6 +29,7 @@ func (d *TemplateDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 		Description: "Use this data source to look up a Cobbler template (4.0.0+).",
 		Attributes: map[string]dsschema.Attribute{
 			"name":          dsschema.StringAttribute{Description: "The name of the template.", Required: true},
+			"uid":           dsschema.StringAttribute{Description: "Server-assigned UID for this template.", Computed: true},
 			"comment":       dsschema.StringAttribute{Description: "Free form text description.", Computed: true},
 			"template_type": dsschema.StringAttribute{Description: "The template engine.", Computed: true},
 			"uri": dsschema.SingleNestedAttribute{
@@ -66,7 +67,17 @@ func (d *TemplateDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	tpl, err := d.client.GetTemplate(data.Name.ValueString(), false, false)
+	matches, err := d.client.FindTemplate(map[string]interface{}{"name": data.Name.ValueString()}, false)
+	if err != nil {
+		resp.Diagnostics.AddError("Error resolving Cobbler Template uid", err.Error())
+		return
+	}
+	uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "Template", data.Name.ValueString(), matches, func(t *cobbler.Template) string { return t.Uid })
+	if !ok {
+		return
+	}
+
+	tpl, err := d.client.GetTemplate(uid, false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler Template", err.Error())
 		return

--- a/internal/template/data_source_model.go
+++ b/internal/template/data_source_model.go
@@ -4,6 +4,7 @@ import "github.com/hashicorp/terraform-plugin-framework/types"
 
 type templateDataSourceModel struct {
 	Name         types.String `tfsdk:"name"`
+	UID          types.String `tfsdk:"uid"`
 	Comment      types.String `tfsdk:"comment"`
 	TemplateType types.String `tfsdk:"template_type"`
 	URI          types.Object `tfsdk:"uri"`

--- a/internal/template/data_source_test.go
+++ b/internal/template/data_source_test.go
@@ -1,6 +1,7 @@
 package template_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/cobbler/terraform-provider-cobbler/internal/acctest"
@@ -25,6 +26,31 @@ func TestAccTemplateDataSource_basic(t *testing.T) {
 		},
 	})
 }
+
+// TestAccTemplateDataSource_notFound exercises the zero-match branch of the data source's
+// name-to-uid resolution: looking up a name that doesn't exist on the server must surface a
+// clear "not found" diagnostic instead of a raw client error.
+func TestAccTemplateDataSource_notFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.SkipIfCobblerVersionLessThan(t, 4, 0, 0)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccTemplateDataSourceNotFound,
+				ExpectError: regexp.MustCompile(`Cobbler Template not found`),
+			},
+		},
+	})
+}
+
+const testAccTemplateDataSourceNotFound = `
+data "cobbler_template" "notfound" {
+  name = "does-not-exist-template-data-source"
+}
+`
 
 const testAccTemplateDataSourceBasic = `
 resource "cobbler_template" "foo" {

--- a/internal/template/resource.go
+++ b/internal/template/resource.go
@@ -54,6 +54,13 @@ func (r *TemplateResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"uid": schema.StringAttribute{
+				Description: "Server-assigned UID for this template.",
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"comment": schema.StringAttribute{
 				Description: "Free form text description.",
 				Optional:    true,
@@ -210,6 +217,7 @@ func templateContent(client cobbler.Client, tpl cobbler.Template, diags *diag.Di
 
 func templateToModel(ctx context.Context, client cobbler.Client, tpl cobbler.Template, data *templateResourceModel, diags *diag.Diagnostics) {
 	data.Name = types.StringValue(tpl.Name)
+	data.UID = types.StringValue(tpl.Uid)
 	data.Comment = types.StringValue(tpl.Comment)
 	data.TemplateType = types.StringValue(tpl.TemplateType)
 	data.URI = uriFromAPI(ctx, tpl.URI, diags)
@@ -227,6 +235,7 @@ func templateToModel(ctx context.Context, client cobbler.Client, tpl cobbler.Tem
 
 func templateToDataSourceModel(ctx context.Context, client cobbler.Client, tpl cobbler.Template, data *templateDataSourceModel, diags *diag.Diagnostics) {
 	data.Name = types.StringValue(tpl.Name)
+	data.UID = types.StringValue(tpl.Uid)
 	data.Comment = types.StringValue(tpl.Comment)
 	data.TemplateType = types.StringValue(tpl.TemplateType)
 	data.URI = uriFromAPI(ctx, tpl.URI, diags)
@@ -277,7 +286,20 @@ func (r *TemplateResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
-	tpl, err := r.client.GetTemplate(data.Name.ValueString(), false, false)
+	if data.UID.IsNull() || data.UID.IsUnknown() || data.UID.ValueString() == "" {
+		matches, err := r.client.FindTemplate(map[string]interface{}{"name": data.Name.ValueString()}, false)
+		if err != nil {
+			resp.Diagnostics.AddError("Error resolving Cobbler Template uid", err.Error())
+			return
+		}
+		uid, ok := clientpkg.ResolveUnique(&resp.Diagnostics, "Template", data.Name.ValueString(), matches, func(t *cobbler.Template) string { return t.Uid })
+		if !ok {
+			return
+		}
+		data.UID = types.StringValue(uid)
+	}
+
+	tpl, err := r.client.GetTemplate(data.UID.ValueString(), false, false)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			resp.State.RemoveResource(ctx)
@@ -314,7 +336,7 @@ func (r *TemplateResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	updated, err := r.client.GetTemplate(tpl.Name, false, false)
+	updated, err := r.client.GetTemplate(data.UID.ValueString(), false, false)
 	if err != nil {
 		resp.Diagnostics.AddError("Error reading Cobbler Template after update", err.Error())
 		return
@@ -337,7 +359,7 @@ func (r *TemplateResource) Delete(ctx context.Context, req resource.DeleteReques
 
 	tflog.Debug(ctx, "Cobbler Template: Delete", map[string]interface{}{"name": data.Name.ValueString()})
 
-	if err := r.client.DeleteTemplate(data.Name.ValueString()); err != nil {
+	if err := r.client.DeleteTemplate(data.UID.ValueString()); err != nil {
 		resp.Diagnostics.AddError("Error deleting Cobbler Template", err.Error())
 	}
 }

--- a/internal/template/resource_model.go
+++ b/internal/template/resource_model.go
@@ -4,6 +4,7 @@ import "github.com/hashicorp/terraform-plugin-framework/types"
 
 type templateResourceModel struct {
 	Name         types.String `tfsdk:"name"`
+	UID          types.String `tfsdk:"uid"`
 	Comment      types.String `tfsdk:"comment"`
 	TemplateType types.String `tfsdk:"template_type"`
 	URI          types.Object `tfsdk:"uri"`

--- a/internal/template/resource_test.go
+++ b/internal/template/resource_test.go
@@ -1,6 +1,7 @@
 package template_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/cobbler/terraform-provider-cobbler/internal/acctest"
@@ -65,6 +66,44 @@ func TestAccTemplateResource_change(t *testing.T) {
 		},
 	})
 }
+
+// TestAccTemplateResource_importNotFound exercises the zero-match branch of the resource's
+// post-import name-to-uid resolution fallback: importing an ID that doesn't match any Template
+// on the server must surface a clear "not found" diagnostic instead of a raw client error.
+func TestAccTemplateResource_importNotFound(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.SkipIfCobblerVersionLessThan(t, 4, 0, 0)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTemplateResourceImportNotFound,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cobbler_template.notfound", "name", "foo-resource-template-import-not-found"),
+				),
+			},
+			{
+				ResourceName:  "cobbler_template.notfound",
+				ImportState:   true,
+				ImportStateId: "does-not-exist-template-resource",
+				ExpectError:   regexp.MustCompile(`Cobbler Template not found`),
+			},
+		},
+	})
+}
+
+const testAccTemplateResourceImportNotFound = `
+resource "cobbler_template" "notfound" {
+  name    = "foo-resource-template-import-not-found"
+  uri = {
+    schema = "file"
+    path   = "foo-resource-template-import-not-found.j2"
+  }
+  content = "# import not found test content\n"
+}
+`
 
 const testAccTemplateResourceBasic = `
 resource "cobbler_template" "foo" {


### PR DESCRIPTION
## Linked Items

Nothing

## Description

Cobbler 4.0.0b4 changed get_item/get_<type> and remove_item/remove_<type> to require an object uid instead of a name. Bump cobblerclient to v1.0.0-rc5 (which already made this change) and adapt:

- Add a computed uid attribute to the six resource/data-source types that didn't have one yet (repo, template, network_interface, distro_group, profile_group, system_group), mirroring the existing pattern on distro/profile/system/image/menu.
- Wire every resource's Read/Update/Delete to use the cached uid instead of name for GetX/DeleteX calls - including the five pre-existing "has uid" resources, whose uid field was sitting unused until now.
- Add a shared internal/client.ResolveUnique helper used by every resource's Read (for the post-import/no-cached-uid fallback) and every data source (which never has a cached uid) to resolve name to uid via Find<Type>, erroring clearly on zero or more than one match.
- Bump docker/start.sh's cobbler_image_tag to v4.0.0b5 and regenerate docs for the newly uid-bearing types.

## Behaviour changes

None

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required
